### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.21.0-alpine as build
+
+WORKDIR /usr/src/app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+WORKDIR cmd
+RUN go build -v -o /usr/local/bin/mocrelay ./...
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /usr/local/bin/mocrelay /
+
+EXPOSE 8234
+
+CMD ["/mocrelay"]


### PR DESCRIPTION
Add a Dockerfile to make it easier to build in all environments.

(NOTE: To actually use this Dockerfile, you'll need to change `localhost:8234` to `0.0.0.0:8234` in `main.go`.)