### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.0-alpine as build
+FROM golang:1.21.0 as build
 
 WORKDIR /usr/src/app
 
@@ -7,7 +7,7 @@ RUN go mod download && go mod verify
 
 COPY . .
 WORKDIR cmd
-RUN go build -v -o /usr/local/bin/mocrelay ./...
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/mocrelay ./...
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /usr/local/bin/mocrelay /


### PR DESCRIPTION
In the current Dockerfile, alpine is used for the build layer and the application is executed in debian, so there was a mismatch, so it will be unified to debian.