### PR TITLE
Fix EventCreatedAtMiddleware#HandleClientMsg

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1070,12 +1070,20 @@ func (m *simpleEventCreatedAtMiddleware) HandleClientMsg(
 ) (<-chan ClientMsg, <-chan ServerMsg, error) {
 	if msg, ok := msg.(*ClientEventMsg); ok {
 		sub := time.Until(msg.Event.CreatedAtTime())
-		if sub < m.from || m.to < -sub {
+		if sub < m.from {
 			smsgCh := newClosedBufCh[ServerMsg](NewServerOKMsg(
 				msg.Event.ID,
 				false,
 				ServerOKMsgPrefixNoPrefix,
 				"too old created_at",
+			))
+			return nil, smsgCh, nil
+		} else if m.to < sub {
+			smsgCh := newClosedBufCh[ServerMsg](NewServerOKMsg(
+				msg.Event.ID,
+				false,
+				ServerOKMsgPrefixNoPrefix,
+				"too far off created_at",
 			))
 			return nil, smsgCh, nil
 		}


### PR DESCRIPTION
Fixed what seemed to be an issue in determining the time for `EventCreatedAtMiddleware#HandleClientMsg`.

By default in `main.go`, `from` is set to -5 minutes and `to` is set to 1 minute.
If an event is received 2 minutes before the current time, a condition of `m.to < -sub` will result in `-sub` being 2 minutes, which is greater than `m.to` (1 minute), and the client will receive a `too old created_at` message.