### PR TITLE
feat: structured logging across handlers, middleware, and storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,39 @@ LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err)
 slog.WarnContext(ctx, "query error", "error", err)
 ```
 
+**Log level policy**:
+
+| Level | What goes here | Examples |
+|---|---|---|
+| **Error** | Data loss / corruption; operator must act now. | Storage.Store failure, unrecoverable I/O. |
+| **Warn** | Unexpected / externally-caused failures; individually tolerable but worth watching. | WebSocket parse / verify failure, MergeHandler lost child (timeout / early close), child handler returned error, Shutdown deadline exceeded. |
+| **Info** | Structural lifecycle events — one per connection or per relay, not per message. | Connection start / end, PebbleStorage / BleveIndex open / close, Relay shutdown progress. |
+| **Debug** | Hot-path events: every accepted EVENT, every REQ, every middleware rejection, every dropped broadcast. Off in production. | `logRejection` output, routerHandler per-message events, MergeHandler EVENT drop. |
+
+Rule of thumb: if the log fires "at Info or higher and would be noisy in
+production under normal load", it is at the wrong level.
+
+**Middleware rejection log helper** (`logRejection`):
+
+Every middleware in mocrelay that drops / rejects a client message calls the
+internal `logRejection` helper so operators can find all rejections with a
+single grep:
+
+```
+grep "message rejected" relay.log
+```
+
+Emitted keys are uniform: `middleware`, `reason`, and message-specific
+extras (e.g. `event_id`, `pubkey`, `sub_id`, `kind`). The `reason` string is
+stable and intentionally aligned with the corresponding Prometheus
+`rejections_total{reason=…}` label where one exists, so logs and metrics are
+cross-indexable.
+
+Rejections are **Debug**, not Warn: they are an expected outcome of normal
+middleware policy (`MaxEventTags` dropping oversized events, `AuthRequired`
+rejecting unauthenticated REQs, …). Enable Debug when investigating why a
+specific client is being dropped; rely on metrics day-to-day.
+
 ### Design Decisions
 
 #### Constructor API

--- a/bleve_index.go
+++ b/bleve_index.go
@@ -27,19 +27,31 @@ type SearchIndex interface {
 
 // BleveIndex implements SearchIndex using Bleve with CJK analyzer.
 type BleveIndex struct {
-	index bleve.Index
+	index  bleve.Index
+	logger *slog.Logger // For Open/Close/lifecycle logs (never nil; falls back to slog.Default()).
 }
 
 // BleveIndexOptions configures BleveIndex behavior.
 type BleveIndexOptions struct {
 	// Path to store the index. If empty, uses in-memory index.
 	Path string
+
+	// Logger is used for lifecycle events (Open, Close) that happen outside
+	// of any request context. Per-request errors continue to use the context
+	// logger via [LoggerFromContext].
+	// Default: [slog.Default]
+	Logger *slog.Logger
 }
 
 // NewBleveIndex creates a new Bleve-based search index.
 func NewBleveIndex(opts *BleveIndexOptions) (*BleveIndex, error) {
 	if opts == nil {
 		opts = &BleveIndexOptions{}
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
 	}
 
 	indexMapping := buildIndexMapping()
@@ -63,11 +75,11 @@ func NewBleveIndex(opts *BleveIndexOptions) (*BleveIndex, error) {
 	}
 
 	if opts.Path == "" {
-		slog.Info("bleve index: opened (in-memory)")
+		logger.Info("bleve index: opened (in-memory)")
 	} else {
-		slog.Info("bleve index: opened", "path", opts.Path)
+		logger.Info("bleve index: opened", "path", opts.Path)
 	}
-	return &BleveIndex{index: index}, nil
+	return &BleveIndex{index: index, logger: logger}, nil
 }
 
 // buildIndexMapping creates the Bleve index mapping for Nostr events.
@@ -170,9 +182,9 @@ func (b *BleveIndex) Delete(ctx context.Context, eventID string) error {
 func (b *BleveIndex) Close() error {
 	err := b.index.Close()
 	if err != nil {
-		slog.Warn("bleve index: close returned error", "error", err)
+		b.logger.Warn("bleve index: close returned error", "error", err)
 	} else {
-		slog.Info("bleve index: closed")
+		b.logger.Info("bleve index: closed")
 	}
 	return err
 }

--- a/bleve_index.go
+++ b/bleve_index.go
@@ -2,6 +2,7 @@ package mocrelay
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis/lang/cjk"
@@ -61,6 +62,11 @@ func NewBleveIndex(opts *BleveIndexOptions) (*BleveIndex, error) {
 		return nil, err
 	}
 
+	if opts.Path == "" {
+		slog.Info("bleve index: opened (in-memory)")
+	} else {
+		slog.Info("bleve index: opened", "path", opts.Path)
+	}
 	return &BleveIndex{index: index}, nil
 }
 
@@ -162,7 +168,13 @@ func (b *BleveIndex) Delete(ctx context.Context, eventID string) error {
 
 // Close implements SearchIndex.Close.
 func (b *BleveIndex) Close() error {
-	return b.index.Close()
+	err := b.index.Close()
+	if err != nil {
+		slog.Warn("bleve index: close returned error", "error", err)
+	} else {
+		slog.Info("bleve index: closed")
+	}
+	return err
 }
 
 func (b *BleveIndex) docCount() (uint64, error) {

--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,19 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 	return slog.Default()
 }
 
+// logRejection logs a middleware-level message rejection at Debug level with
+// a uniform key set. All middleware drops in mocrelay call this helper so
+// operators can find them with a single grep of "message rejected".
+//
+// Rejections are Debug (not Warn) because they are an expected outcome of
+// normal middleware policy and would otherwise flood the log. Enable Debug
+// logging when investigating why a specific client's messages are being
+// dropped.
+func logRejection(ctx context.Context, middleware, reason string, attrs ...any) {
+	base := []any{"middleware", middleware, "reason", reason}
+	LoggerFromContext(ctx).DebugContext(ctx, "message rejected", append(base, attrs...)...)
+}
+
 type connIDKey struct{}
 
 // contextWithConnID returns a new context with the given connection ID.

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,8 +1,10 @@
 package mocrelay
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +23,50 @@ func TestLoggerFromContext(t *testing.T) {
 		got := LoggerFromContext(ctx)
 		if got != logger {
 			t.Fatal("expected the same logger")
+		}
+	})
+}
+
+func TestLogRejection(t *testing.T) {
+	t.Run("emits debug log with uniform keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+		ctx := ContextWithLogger(context.Background(), logger)
+
+		logRejection(ctx, "max_event_tags", "too_many_tags",
+			"event_id", "abc123",
+			"count", 100,
+		)
+
+		out := buf.String()
+		for _, want := range []string{
+			`level=DEBUG`,
+			`msg="message rejected"`,
+			`middleware=max_event_tags`,
+			`reason=too_many_tags`,
+			`event_id=abc123`,
+			`count=100`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q\nfull output: %s", want, out)
+			}
+		}
+	})
+
+	t.Run("default logger skips debug by default", func(t *testing.T) {
+		// logRejection is Debug level, so it should be silent under the
+		// default logger (Info level). This guards against accidentally
+		// promoting it to a higher level.
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil)) // default: Info
+		ctx := ContextWithLogger(context.Background(), logger)
+
+		logRejection(ctx, "auth", "event_unauthenticated", "event_id", "x")
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no output at Info level, got: %s", buf.String())
 		}
 	})
 }

--- a/merge_handler.go
+++ b/merge_handler.go
@@ -63,13 +63,21 @@ func (h *mergeHandler) broadcastAll(
 	childRecvs []chan *ClientMsg,
 ) (dead []int, ctxDone bool) {
 	if msg.Type == MsgTypeEvent {
-		for _, ch := range childRecvs {
+		for i, ch := range childRecvs {
 			if ch == nil {
 				continue
 			}
 			select {
 			case ch <- msg:
 			default:
+				// Best-effort: child recv buffer is full. The client
+				// will learn of the loss via OK accepted=false (see
+				// handlerClosed / hadHandlerLoss).
+				LoggerFromContext(ctx).DebugContext(ctx,
+					"merge handler: EVENT dropped to child (recv buffer full)",
+					"handler_index", i,
+					"event_id", msg.Event.ID,
+				)
 			}
 		}
 		return nil, false
@@ -93,6 +101,12 @@ func (h *mergeHandler) broadcastAll(
 		case ch <- msg:
 			t.Stop()
 		case <-t.C:
+			LoggerFromContext(ctx).WarnContext(ctx,
+				"merge handler: child broadcast timed out, retiring child",
+				"handler_index", i,
+				"msg_type", msg.Type,
+				"timeout", h.broadcastTimeout,
+			)
 			dead = append(dead, i)
 		case <-ctx.Done():
 			t.Stop()
@@ -149,6 +163,9 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 
 	numHandlers := len(h.handlers)
 
+	logger := LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "merge handler: started", "num_handlers", numHandlers)
+
 	// Create channels for each child handler. childRecvs uses an internal
 	// default buffer size; childSends is fixed because the merger drains it
 	// directly from the main loop and no buffering matters beyond a small
@@ -171,6 +188,11 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 			defer wg.Done()
 			defer close(childSends[i])
 			if err := handler.ServeNostr(ctx, childSends[i], childRecvs[i]); err != nil {
+				LoggerFromContext(ctx).WarnContext(ctx,
+					"merge handler: child returned error",
+					"handler_index", i,
+					"error", err,
+				)
 				errs <- fmt.Errorf("handler %d: %w", i, err)
 			}
 		}(i, handler)
@@ -254,6 +276,10 @@ loop:
 				// Child closed: disable this case and advance any pending
 				// state still waiting on this handler so the client isn't
 				// left hanging on OK / EOSE / COUNT.
+				LoggerFromContext(ctx).WarnContext(ctx,
+					"merge handler: child closed its send channel",
+					"handler_index", handlerIndex,
+				)
 				cases[chosen].Chan = reflect.ValueOf(nil)
 				results := session.handlerClosed(handlerIndex)
 				if !sendAll(ctx, send, results) {
@@ -280,7 +306,13 @@ loop:
 		handlerErrs = errors.Join(handlerErrs, e)
 	}
 
-	return errors.Join(loopErr, handlerErrs)
+	finalErr := errors.Join(loopErr, handlerErrs)
+	if finalErr != nil {
+		logger.DebugContext(ctx, "merge handler: stopped", "error", finalErr)
+	} else {
+		logger.DebugContext(ctx, "merge handler: stopped")
+	}
+	return finalErr
 }
 
 // mergeSession manages the state for merging responses.

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -100,13 +100,17 @@ func (m *authMiddleware) HandleClientMsg(
 
 	switch msg.Type {
 	case MsgTypeAuth:
-		return m.handleAuth(state, msg)
+		return m.handleAuth(ctx, state, msg)
 
 	case MsgTypeEvent:
 		if !m.isAuthedPubkey(state, msg.Event.Pubkey) {
 			if m.metrics != nil {
 				m.metrics.RejectionsTotal.WithLabelValues("event_unauthenticated").Inc()
 			}
+			logRejection(ctx, "auth", "event_unauthenticated",
+				"event_id", msg.Event.ID,
+				"pubkey", msg.Event.Pubkey,
+			)
 			return nil, NewServerOKMsg(
 				msg.Event.ID,
 				false,
@@ -120,6 +124,9 @@ func (m *authMiddleware) HandleClientMsg(
 			if m.metrics != nil {
 				m.metrics.RejectionsTotal.WithLabelValues("req_unauthenticated").Inc()
 			}
+			logRejection(ctx, "auth", "req_unauthenticated",
+				"sub_id", msg.SubscriptionID,
+			)
 			return nil, NewServerClosedMsg(
 				msg.SubscriptionID,
 				"auth-required: authentication required to subscribe",
@@ -140,8 +147,9 @@ func (m *authMiddleware) HandleServerMsg(
 	return msg, nil
 }
 
-func (m *authMiddleware) handleAuth(state *authState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
 	if msg.Event == nil {
+		logRejection(ctx, "auth", "missing_auth_event")
 		return nil, NewServerOKMsg("", false, "invalid: missing auth event"), nil
 	}
 
@@ -152,6 +160,10 @@ func (m *authMiddleware) handleAuth(state *authState, msg *ClientMsg) (*ClientMs
 		if m.metrics != nil {
 			m.metrics.AuthTotal.WithLabelValues("invalid_kind").Inc()
 		}
+		logRejection(ctx, "auth", "invalid_kind",
+			"event_id", event.ID,
+			"kind", event.Kind,
+		)
 		return nil, NewServerOKMsg(event.ID, false, "invalid: auth event must be kind 22242"), nil
 	}
 
@@ -161,6 +173,10 @@ func (m *authMiddleware) handleAuth(state *authState, msg *ClientMsg) (*ClientMs
 		if m.metrics != nil {
 			m.metrics.AuthTotal.WithLabelValues("expired").Inc()
 		}
+		logRejection(ctx, "auth", "expired",
+			"event_id", event.ID,
+			"created_at", event.CreatedAt.Unix(),
+		)
 		return nil, NewServerOKMsg(event.ID, false, "invalid: auth event created_at out of range"), nil
 	}
 
@@ -174,6 +190,9 @@ func (m *authMiddleware) handleAuth(state *authState, msg *ClientMsg) (*ClientMs
 		if m.metrics != nil {
 			m.metrics.AuthTotal.WithLabelValues("challenge_mismatch").Inc()
 		}
+		logRejection(ctx, "auth", "challenge_mismatch",
+			"event_id", event.ID,
+		)
 		return nil, NewServerOKMsg(event.ID, false, "invalid: challenge mismatch"), nil
 	}
 
@@ -186,6 +205,9 @@ func (m *authMiddleware) handleAuth(state *authState, msg *ClientMsg) (*ClientMs
 			if m.metrics != nil {
 				m.metrics.AuthTotal.WithLabelValues("invalid_relay").Inc()
 			}
+			logRejection(ctx, "auth", "missing_relay_tag",
+				"event_id", event.ID,
+			)
 			return nil, NewServerOKMsg(event.ID, false, "invalid: missing relay tag"), nil
 		}
 	}

--- a/middleware_created_at_limits.go
+++ b/middleware_created_at_limits.go
@@ -54,6 +54,11 @@ func (m *createdAtLimitsMiddleware) HandleClientMsg(ctx context.Context, msg *Cl
 	// Check lower limit (too old)
 	oldest := now.Add(-time.Duration(m.lowerLimit) * time.Second)
 	if createdAt.Before(oldest) {
+		logRejection(ctx, "created_at_limits", "too_old",
+			"event_id", msg.Event.ID,
+			"created_at", createdAt.Unix(),
+			"lower_limit_sec", m.lowerLimit,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "invalid: created_at too old")
 		return nil, resp, nil
 	}
@@ -61,6 +66,11 @@ func (m *createdAtLimitsMiddleware) HandleClientMsg(ctx context.Context, msg *Cl
 	// Check upper limit (too far in the future)
 	newest := now.Add(time.Duration(m.upperLimit) * time.Second)
 	if createdAt.After(newest) {
+		logRejection(ctx, "created_at_limits", "too_far_future",
+			"event_id", msg.Event.ID,
+			"created_at", createdAt.Unix(),
+			"upper_limit_sec", m.upperLimit,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "invalid: created_at too far in the future")
 		return nil, resp, nil
 	}

--- a/middleware_expiration.go
+++ b/middleware_expiration.go
@@ -33,6 +33,9 @@ func (m *expirationMiddleware) HandleClientMsg(ctx context.Context, msg *ClientM
 	}
 
 	if m.isExpired(msg.Event) {
+		logRejection(ctx, "expiration", "expired",
+			"event_id", msg.Event.ID,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "invalid: event has expired")
 		return nil, resp, nil
 	}
@@ -44,6 +47,9 @@ func (m *expirationMiddleware) HandleServerMsg(ctx context.Context, msg *ServerM
 	// Drop expired events from being delivered
 	if msg.Type == MsgTypeEvent && msg.Event != nil {
 		if m.isExpired(msg.Event) {
+			logRejection(ctx, "expiration", "expired_on_send",
+				"event_id", msg.Event.ID,
+			)
 			return nil, nil // drop
 		}
 	}

--- a/middleware_kind_denylist.go
+++ b/middleware_kind_denylist.go
@@ -37,6 +37,10 @@ func (m *kindDenylistMiddleware) HandleClientMsg(ctx context.Context, msg *Clien
 	}
 
 	if _, denied := m.denylist[msg.Event.Kind]; denied {
+		logRejection(ctx, "kind_denylist", "kind_blocked",
+			"event_id", msg.Event.ID,
+			"kind", msg.Event.Kind,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "blocked: kind not allowed")
 		return nil, resp, nil
 	}

--- a/middleware_max_content_length.go
+++ b/middleware_max_content_length.go
@@ -34,6 +34,11 @@ func (m *maxContentLengthMiddleware) HandleClientMsg(ctx context.Context, msg *C
 	}
 
 	if msg.Event != nil && utf8.RuneCountInString(msg.Event.Content) > m.maxLen {
+		logRejection(ctx, "max_content_length", "content_too_long",
+			"event_id", msg.Event.ID,
+			"length", utf8.RuneCountInString(msg.Event.Content),
+			"limit", m.maxLen,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "invalid: content too long")
 		return nil, resp, nil
 	}

--- a/middleware_max_event_tags.go
+++ b/middleware_max_event_tags.go
@@ -31,6 +31,11 @@ func (m *maxEventTagsMiddleware) HandleClientMsg(ctx context.Context, msg *Clien
 	}
 
 	if msg.Event != nil && len(msg.Event.Tags) > m.maxTags {
+		logRejection(ctx, "max_event_tags", "too_many_tags",
+			"event_id", msg.Event.ID,
+			"tags", len(msg.Event.Tags),
+			"limit", m.maxTags,
+		)
 		resp := NewServerOKMsg(msg.Event.ID, false, "invalid: too many tags")
 		return nil, resp, nil
 	}

--- a/middleware_max_subid_length.go
+++ b/middleware_max_subid_length.go
@@ -29,6 +29,10 @@ func (m *maxSubidLengthMiddleware) HandleClientMsg(ctx context.Context, msg *Cli
 	switch msg.Type {
 	case MsgTypeReq, MsgTypeClose:
 		if len(msg.SubscriptionID) > m.maxLen {
+			logRejection(ctx, "max_subid_length", "subid_too_long",
+				"sub_id_length", len(msg.SubscriptionID),
+				"limit", m.maxLen,
+			)
 			resp := NewServerClosedMsg(msg.SubscriptionID, "error: subscription ID too long")
 			return nil, resp, nil
 		}

--- a/middleware_max_subscriptions.go
+++ b/middleware_max_subscriptions.go
@@ -42,7 +42,7 @@ func (m *maxSubscriptionsMiddleware) HandleClientMsg(ctx context.Context, msg *C
 
 	switch msg.Type {
 	case MsgTypeReq:
-		return m.handleReq(state, msg)
+		return m.handleReq(ctx, state, msg)
 	case MsgTypeClose:
 		return m.handleClose(state, msg)
 	default:
@@ -50,7 +50,7 @@ func (m *maxSubscriptionsMiddleware) HandleClientMsg(ctx context.Context, msg *C
 	}
 }
 
-func (m *maxSubscriptionsMiddleware) handleReq(state *maxSubsState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+func (m *maxSubscriptionsMiddleware) handleReq(ctx context.Context, state *maxSubsState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
@@ -63,6 +63,11 @@ func (m *maxSubscriptionsMiddleware) handleReq(state *maxSubsState, msg *ClientM
 
 	// Check if we've reached the limit
 	if len(state.subs) >= m.maxSubs {
+		logRejection(ctx, "max_subscriptions", "too_many_subscriptions",
+			"sub_id", subID,
+			"current", len(state.subs),
+			"limit", m.maxSubs,
+		)
 		// Reject with CLOSED message
 		resp := NewServerClosedMsg(subID, "error: too many subscriptions")
 		return nil, resp, nil

--- a/middleware_min_pow_difficulty.go
+++ b/middleware_min_pow_difficulty.go
@@ -48,6 +48,11 @@ func (m *minPowDifficultyMiddleware) HandleClientMsg(
 	// Check actual difficulty
 	actualDifficulty := countLeadingZeroBits(event.ID)
 	if actualDifficulty < m.minDifficulty {
+		logRejection(ctx, "min_pow_difficulty", "insufficient_difficulty",
+			"event_id", event.ID,
+			"actual", actualDifficulty,
+			"required", m.minDifficulty,
+		)
 		return nil, NewServerOKMsg(
 			event.ID,
 			false,
@@ -59,6 +64,11 @@ func (m *minPowDifficultyMiddleware) HandleClientMsg(
 	if m.checkCommitment {
 		committedTarget := getCommittedPowTarget(event)
 		if committedTarget >= 0 && committedTarget < m.minDifficulty {
+			logRejection(ctx, "min_pow_difficulty", "insufficient_committed_target",
+				"event_id", event.ID,
+				"committed", committedTarget,
+				"required", m.minDifficulty,
+			)
 			return nil, NewServerOKMsg(
 				event.ID,
 				false,

--- a/middleware_protected_events.go
+++ b/middleware_protected_events.go
@@ -36,6 +36,10 @@ func (m *protectedEventsMiddleware) HandleClientMsg(ctx context.Context, msg *Cl
 
 	// Check if the authenticated pubkey matches the event pubkey
 	if !isAuthedAsPubkey(ctx, msg.Event.Pubkey) {
+		logRejection(ctx, "protected_events", "not_authed_as_author",
+			"event_id", msg.Event.ID,
+			"pubkey", msg.Event.Pubkey,
+		)
 		resp := NewServerOKMsg(
 			msg.Event.ID,
 			false,

--- a/middleware_restricted_writes.go
+++ b/middleware_restricted_writes.go
@@ -57,11 +57,19 @@ func (m *restrictedWritesMiddleware) HandleClientMsg(ctx context.Context, msg *C
 	switch m.mode {
 	case RestrictedWritesModeAllowlist:
 		if !inList {
+			logRejection(ctx, "restricted_writes", "not_in_allowlist",
+				"event_id", msg.Event.ID,
+				"pubkey", msg.Event.Pubkey,
+			)
 			resp := NewServerOKMsg(msg.Event.ID, false, "restricted: pubkey not allowed")
 			return nil, resp, nil
 		}
 	case RestrictedWritesModeBlocklist:
 		if inList {
+			logRejection(ctx, "restricted_writes", "in_blocklist",
+				"event_id", msg.Event.ID,
+				"pubkey", msg.Event.Pubkey,
+			)
 			resp := NewServerOKMsg(msg.Event.ID, false, "restricted: pubkey blocked")
 			return nil, resp, nil
 		}

--- a/pebble_storage.go
+++ b/pebble_storage.go
@@ -46,9 +46,10 @@ const (
 
 // PebbleStorage implements Storage using Pebble (LSM-tree based KV store).
 type PebbleStorage struct {
-	db    *pebble.DB
-	cache *pebble.Cache // Keep reference to close on Close()
-	mu    sync.RWMutex  // For atomic operations spanning multiple keys
+	db     *pebble.DB
+	cache  *pebble.Cache // Keep reference to close on Close()
+	logger *slog.Logger  // For Open/Close/lifecycle logs (never nil; falls back to slog.Default()).
+	mu     sync.RWMutex  // For atomic operations spanning multiple keys
 }
 
 // PebbleStorageOptions configures PebbleStorage behavior.
@@ -58,6 +59,12 @@ type PebbleStorageOptions struct {
 	// SSTable blocks in memory.
 	// Default: 8MB (Pebble's default). Recommended: 64MB-256MB for production.
 	CacheSize int64
+
+	// Logger is used for lifecycle events (Open, Close) that happen outside
+	// of any request context. Per-request errors (Store / Query) continue to
+	// use the context logger via [LoggerFromContext].
+	// Default: [slog.Default]
+	Logger *slog.Logger
 
 	// fs provides the interface for persistent file storage (unexported: test use only).
 	// Use vfs.NewMem() for in-memory storage.
@@ -71,6 +78,11 @@ type PebbleStorageOptions struct {
 func NewPebbleStorage(path string, opts *PebbleStorageOptions) (*PebbleStorage, error) {
 	if opts == nil {
 		opts = &PebbleStorageOptions{}
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
 	}
 
 	// Configure Bloom filter for efficient negative lookups.
@@ -112,8 +124,8 @@ func NewPebbleStorage(path string, opts *PebbleStorageOptions) (*PebbleStorage, 
 		}
 		return nil, fmt.Errorf("open pebble database: %w", err)
 	}
-	slog.Info("pebble storage: opened", "path", path, "cache_size", opts.CacheSize)
-	return &PebbleStorage{db: db, cache: cache}, nil
+	logger.Info("pebble storage: opened", "path", path, "cache_size", opts.CacheSize)
+	return &PebbleStorage{db: db, cache: cache, logger: logger}, nil
 }
 
 // Close closes the Pebble database.
@@ -123,9 +135,9 @@ func (s *PebbleStorage) Close() error {
 		s.cache.Unref()
 	}
 	if err != nil {
-		slog.Warn("pebble storage: close returned error", "error", err)
+		s.logger.Warn("pebble storage: close returned error", "error", err)
 	} else {
-		slog.Info("pebble storage: closed")
+		s.logger.Info("pebble storage: closed")
 	}
 	return err
 }

--- a/pebble_storage.go
+++ b/pebble_storage.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"iter"
+	"log/slog"
 	"math"
 	"sort"
 	"strconv"
@@ -111,6 +112,7 @@ func NewPebbleStorage(path string, opts *PebbleStorageOptions) (*PebbleStorage, 
 		}
 		return nil, fmt.Errorf("open pebble database: %w", err)
 	}
+	slog.Info("pebble storage: opened", "path", path, "cache_size", opts.CacheSize)
 	return &PebbleStorage{db: db, cache: cache}, nil
 }
 
@@ -119,6 +121,11 @@ func (s *PebbleStorage) Close() error {
 	err := s.db.Close()
 	if s.cache != nil {
 		s.cache.Unref()
+	}
+	if err != nil {
+		slog.Warn("pebble storage: close returned error", "error", err)
+	} else {
+		slog.Info("pebble storage: closed")
 	}
 	return err
 }

--- a/relay.go
+++ b/relay.go
@@ -121,10 +121,13 @@ func (r *Relay) Wait() {
 func (r *Relay) Shutdown(ctx context.Context) error {
 	r.mu.Lock()
 	r.closed = true
+	numConns := len(r.cancels)
 	for _, cancel := range r.cancels {
 		cancel()
 	}
 	r.mu.Unlock()
+
+	r.logger.InfoContext(ctx, "relay: shutdown initiated", "active_conns", numConns)
 
 	done := make(chan struct{})
 	go func() {
@@ -134,8 +137,10 @@ func (r *Relay) Shutdown(ctx context.Context) error {
 
 	select {
 	case <-done:
+		r.logger.InfoContext(ctx, "relay: shutdown complete")
 		return nil
 	case <-ctx.Done():
+		r.logger.WarnContext(ctx, "relay: shutdown deadline exceeded, some connections may not have drained")
 		return ctx.Err()
 	}
 }

--- a/router_handler.go
+++ b/router_handler.go
@@ -17,9 +17,15 @@ type routerHandler struct {
 }
 
 func (h *routerHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, recv <-chan *ClientMsg) error {
+	logger := LoggerFromContext(ctx)
+
 	// Register this connection
 	connID := h.router.Register(send)
-	defer h.router.Unregister(connID)
+	logger.DebugContext(ctx, "router handler: registered", "router_conn_id", connID)
+	defer func() {
+		h.router.Unregister(connID)
+		logger.DebugContext(ctx, "router handler: unregistered", "router_conn_id", connID)
+	}()
 
 	for {
 		select {
@@ -43,11 +49,19 @@ func (h *routerHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, 
 
 					// Broadcast to all matching subscriptions
 					h.router.Broadcast(msg.Event)
+					logger.DebugContext(ctx, "router handler: broadcast",
+						"event_id", msg.Event.ID,
+						"kind", msg.Event.Kind,
+					)
 				}
 
 			case MsgTypeReq:
 				// Register subscription
 				h.router.Subscribe(connID, msg.SubscriptionID, msg.Filters)
+				logger.DebugContext(ctx, "router handler: subscribed",
+					"sub_id", msg.SubscriptionID,
+					"num_filters", len(msg.Filters),
+				)
 
 				// Send EOSE (no stored events for now)
 				select {
@@ -59,6 +73,9 @@ func (h *routerHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, 
 			case MsgTypeClose:
 				// Unsubscribe
 				h.router.Unsubscribe(connID, msg.SubscriptionID)
+				logger.DebugContext(ctx, "router handler: unsubscribed",
+					"sub_id", msg.SubscriptionID,
+				)
 
 			case MsgTypeCount:
 				// Return count of 0 (no storage)


### PR DESCRIPTION
## Summary

Wires structured logging into points that were previously silent —
`MergeHandler`, `routerHandler`, the 12 middleware, `PebbleStorage`,
`BleveIndex`, and `Relay.Shutdown` — under a single, consistent level
policy.

- **Warn**: unexpected externally-caused failures (MergeHandler lost
  children via `BroadcastTimeout` or early close, child handler errors,
  shutdown deadline exceeded).
- **Info**: structural lifecycle events (Pebble / Bleve open / close,
  relay shutdown progress).
- **Debug**: hot-path events and all middleware rejections. Silent in
  production by default; enable when investigating a specific drop.

## The `logRejection` helper

New internal helper in `logger.go`. Every middleware that drops a client
message now calls it, producing a uniform `"message rejected"` Debug log
with `middleware` / `reason` / extras (`event_id`, `pubkey`, `sub_id`,
`kind`, …). All drops are grep-able with one query:

```
grep "message rejected" relay.log
```

`reason` strings are intentionally aligned with existing
`rejections_total{reason=...}` Prometheus labels where one exists, so
logs and metrics cross-index cleanly.

## Notes

- `Router` public API (non-ctx-taking) was **not** changed; logging was
  added on the `routerHandler` side where `ctx` is available. Broadcast
  drops remain observable via the existing `MessagesDropped` metric.
- `middleware_max_limit.go` has no rejection (it clamps silently) and is
  unchanged.
- `CLAUDE.md` gets a new sub-section documenting the level policy and
  the `logRejection` contract, so this stays coherent as more middleware
  are added.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green (incl. new `TestLogRejection` covering uniform-keys output + Debug-level gating)
- [x] `go build ./...` green across examples
- [ ] Manual: run `mocrelay` with `slog.HandlerOptions{Level: slog.LevelDebug}` and confirm middleware drops + MergeHandler events appear
- [ ] Manual: confirm Info-level default is quiet (no spam under normal traffic)

🎉 Generated with [Claude Code](https://claude.com/claude-code)