### PR TITLE
fix: demote merge handler child cancel logs from Warn to Debug

### DIFF
--- a/merge_handler.go
+++ b/merge_handler.go
@@ -188,11 +188,22 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 			defer wg.Done()
 			defer close(childSends[i])
 			if err := handler.ServeNostr(ctx, childSends[i], childRecvs[i]); err != nil {
-				LoggerFromContext(ctx).WarnContext(ctx,
-					"merge handler: child returned error",
-					"handler_index", i,
-					"error", err,
-				)
+				logger := LoggerFromContext(ctx)
+				if errors.Is(err, context.Canceled) {
+					// Normal shutdown path: parent ctx was canceled and the
+					// child propagated it back. Not worth a Warn — Relay
+					// already logs "connection end (canceled)" at Info.
+					logger.DebugContext(ctx,
+						"merge handler: child canceled",
+						"handler_index", i,
+					)
+				} else {
+					logger.WarnContext(ctx,
+						"merge handler: child returned error",
+						"handler_index", i,
+						"error", err,
+					)
+				}
 				errs <- fmt.Errorf("handler %d: %w", i, err)
 			}
 		}(i, handler)


### PR DESCRIPTION
## Summary

Salmon の本番ログから見つけた小ノイズの修正です 🌸

正常な接続終了パスでは、parent ctx が cancel されて、各 child handler が `ServeNostr` から `context.Canceled` を返してきます。これを child ごとに Warn で出していたので、**普通の切断のたびに N 行の WARN** が並んでいました：

```
INFO  connection start
WARN  merge handler: child returned error error="context canceled"
WARN  merge handler: child returned error error="context canceled"
INFO  connection end (canceled)
```

`context.Canceled` だけ Debug に落とします。Relay 本体は同じイベントを Info で `"connection end (canceled)"` と落ち着いて出しているので、それと一貫します。本物の handler error は引き続き Warn のまま。

`errs` channel への送出はそのまま残しているので、merge semantics（`hadHandlerLoss` → OK `accepted=false`）には影響しません。**ログだけ静かにする変更**です。

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`（全 PASS）
- [ ] salmon にデプロイして「正常切断時に WARN が出ない／実エラー時には Warn が残る」を実ログで確認

🌸 Generated with [Claude Code](https://claude.com/claude-code)