### PR TITLE
docs: add Metrics policy section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,121 @@ middleware policy (`MaxEventTags` dropping oversized events, `AuthRequired`
 rejecting unauthenticated REQs, …). Enable Debug when investigating why a
 specific client is being dropped; rely on metrics day-to-day.
 
+### Metrics
+
+**Observability stance**: metrics and logs are complementary. Logs (from
+`logRejection` etc.) are the per-event narrative — searchable, costly to
+retain long-term. Metrics are the aggregated time series — cheap,
+cross-indexable with log `reason` labels. Always instrument both.
+
+#### Framing: RED and USE
+
+Two methods cover different questions and are used together, not
+interchangeably:
+
+- **RED method** (Rate / Errors / Duration) — applied to **request-driven
+  paths**: EVENT handling, REQ handling, Store, Query, middleware, Bleve
+  search. Answers "is the client experience OK?"
+- **USE method** (Utilization / Saturation / Errors) — applied to
+  **resources**: connections, subscriptions, send buffers, Pebble WAL,
+  goroutines. Answers "is anything inside starting to choke?"
+
+A request path can be slow (RED-Duration bad) *because* a resource is
+saturated (USE-Saturation bad). You need both axes to see causation, so
+add the RED pair and the USE pair together.
+
+#### Cardinality rules
+
+| Rule | Labels |
+|---|---|
+| **Never** | `pubkey`, `conn_id`, `sub_id`, `ip`, `event_id`, free-form message strings |
+| **Careful** | `kind` — bounded in spec (0-65535) but mocrelay accepts arbitrary `int64`. A hostile client can explode the series set. See Known Concerns below. |
+| **Safe** | Stable enum strings: `type` (EVENT / REQ / …), `reason`, `result`, `middleware` name |
+
+Rule of thumb: if you cannot enumerate the full label-value set at code
+review time, the label is probably too cardinal.
+
+#### Layer convention — count at both ends and subtract
+
+- **Outer (Relay / routerHandler)**: count everything *received* on the
+  wire, before middleware. This is the rate the relay is being offered.
+- **Inner (Storage / MergeHandler accepted path)**: count everything
+  *accepted*. This is what actually took effect.
+- **Difference = amount rejected by middleware.** Each middleware emits
+  its own `rejections_total{middleware, reason}` counter so the breakdown
+  is visible by cause.
+
+#### Log ↔ metric cross-index
+
+Every middleware that calls `logRejection` also increments
+`rejections_total{middleware, reason}` with the **same `reason` string**.
+`grep reason=max_content_length relay.log` and
+`rate(mocrelay_rejections_total{reason="max_content_length"}[5m])` should
+land on the same events. Today only `AuthMiddleware` does this — extending
+to all middleware is the primary follow-up.
+
+#### Instrument choice
+
+| Instrument | When | Hot-path note |
+|---|---|---|
+| **Counter** | Any monotonic count (requests, errors, rejections, drops, bytes in / out) | Lock-free, cheap; fine on every message |
+| **Gauge** | Current level (connections, subscriptions, buffer depth) | Must have matched Inc / Dec (`defer`, cleanup, or `Set`) or it drifts upward forever |
+| **Histogram** | Latency / size distributions where the tail matters | More expensive than Counter; acceptable per REQ / per Store. For per-EVENT hot paths, audit buckets first |
+
+#### Nil-safe injection
+
+Metrics are optional, matching the philosophy of `Relay.Logger`. Each of
+`RelayMetrics`, `RouterMetrics`, `AuthMetrics`, `StorageMetrics` is passed
+through `*Options`; `nil` means "don't measure, don't allocate." Call
+sites guard with a nil check (or a no-op shim) so the instrument-free
+build path has zero runtime cost and no Prometheus dependency surface.
+Just as `Logger == nil` falls back to `slog.Default()`, `Metrics == nil`
+falls back to silence.
+
+#### Coverage by layer (drives follow-up PRs)
+
+| Layer | Kind | Existing | Gaps (future PRs) |
+|---|---|---|---|
+| **Relay (WS conn)** | RED-R | `ConnectionsTotal`, `MessagesReceived{type}`, `MessagesSent{type}`, `EventsReceived{kind}` | — |
+| | RED-E | — | `ws_parse_errors_total`, `ws_write_errors_total` |
+| | RED-D | — | `ws_write_duration_seconds` (diagnose write timeouts) |
+| | USE-Sat | `ConnectionsCurrent` | `send_buf_full_drops_total`, `write_timeouts_total` |
+| **Router** | USE-Sat | `MessagesDropped` | `subscriptions_current` (Gauge) |
+| **Middleware: Auth** | RED-R+E | `AuthTotal{result}`, `RejectionsTotal{reason}`, `AuthenticatedConnectionsCurrent` | — |
+| **Middleware: others (11)** | RED-E | — | Unified `rejections_total{middleware, reason}`, aligned with `logRejection` |
+| **StorageHandler** | RED-R+D | `EventsStored{kind, stored}`, `Store / QueryDuration` | `store_errors_total`, `query_errors_total` |
+| **MergeHandler** | USE-Sat+E | — | `lost_children_total`, `broadcast_timeouts_total`, `event_sort_drops_total` |
+| **Pebble (internals)** | USE | — | Expose `pebble.Metrics()` — L0 files, compactions, WAL bytes |
+| **Bleve** | RED-R+D+E | — | `search_total`, `search_duration_seconds`, `search_errors_total` |
+
+#### Known concerns (decide before v0.x freeze)
+
+1. **`kind` label explosion**: `EventsReceived{kind}` and
+   `EventsStored{kind, stored}` accept arbitrary `int64`. A malicious or
+   buggy client sending a unique kind per message would grow the series
+   set without bound. Candidate fixes (to be decided):
+   - **Allowlist of known kinds** (0, 1, 3, 4, 5, 6, 7, 40-44, 1984,
+     9734, 9735, 10000-19999, 30000-39999, …) with everything else
+     bucketed to `kind="other"`. Preserves per-kind fidelity for the
+     common case.
+   - **Range buckets** aligned with NIP-01 categories: `regular`,
+     `replaceable`, `ephemeral`, `addressable`, `other`. Loses per-kind
+     detail but cardinality is fixed at 5.
+   - **Drop the `kind` label entirely** and recover kind-level breakdown
+     from the event log instead.
+
+2. **Per-middleware counter alignment**: today `RejectionsTotal` lives on
+   `AuthMetrics` with two reasons. The follow-up should promote this to a
+   relay-wide `mocrelay_rejections_total{middleware, reason}` so every
+   `logRejection` call has a matching metric increment and the
+   `{middleware, reason}` cross-product stays a closed enum.
+
+3. **Pebble / Bleve internals**: `pebble.Metrics()` returns rich
+   saturation signals (L0 files, pending compactions, WAL bytes) that are
+   not exposed today. The usual pattern is a periodic collector goroutine
+   reading `Metrics()` every N seconds into Gauges. Out of scope for the
+   initial policy PR.
+
 ### Design Decisions
 
 #### Constructor API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,17 +207,24 @@ review time, the label is probably too cardinal.
 - **Inner (Storage / MergeHandler accepted path)**: count everything
   *accepted*. This is what actually took effect.
 - **Difference = amount rejected by middleware.** Each middleware emits
-  its own `rejections_total{middleware, reason}` counter so the breakdown
-  is visible by cause.
+  its own `<middleware>_rejections_total{reason}` counter (one metric
+  name per middleware, not a shared `{middleware, reason}` dimension),
+  so the breakdown is visible by cause while each middleware's metric
+  surface stays independent.
 
 #### Log ↔ metric cross-index
 
-Every middleware that calls `logRejection` also increments
-`rejections_total{middleware, reason}` with the **same `reason` string**.
-`grep reason=max_content_length relay.log` and
-`rate(mocrelay_rejections_total{reason="max_content_length"}[5m])` should
-land on the same events. Today only `AuthMiddleware` does this — extending
-to all middleware is the primary follow-up.
+Every middleware that calls `logRejection` also increments its own
+rejection counter, carrying the **same `reason` string** as a label. The
+shared key is the `reason` value, not a unified metric name:
+
+```
+grep reason=max_content_length relay.log
+rate({__name__=~"mocrelay_.*_rejections_total", reason="max_content_length"}[5m])
+```
+
+should land on the same events. Today only `AuthMiddleware` is wired —
+extending to all middleware is the primary follow-up.
 
 #### Instrument choice
 
@@ -247,7 +254,7 @@ falls back to silence.
 | | USE-Sat | `ConnectionsCurrent` | `send_buf_full_drops_total`, `write_timeouts_total` |
 | **Router** | USE-Sat | `MessagesDropped` | `subscriptions_current` (Gauge) |
 | **Middleware: Auth** | RED-R+E | `AuthTotal{result}`, `RejectionsTotal{reason}`, `AuthenticatedConnectionsCurrent` | — |
-| **Middleware: others (11)** | RED-E | — | Unified `rejections_total{middleware, reason}`, aligned with `logRejection` |
+| **Middleware: others (11)** | RED-E | — | Per-middleware `<name>_rejections_total{reason}`, aligned with `logRejection` |
 | **StorageHandler** | RED-R+D | `EventsStored{kind, stored}`, `Store / QueryDuration` | `store_errors_total`, `query_errors_total` |
 | **MergeHandler** | USE-Sat+E | — | `lost_children_total`, `broadcast_timeouts_total`, `event_sort_drops_total` |
 | **Pebble (internals)** | USE | — | Expose `pebble.Metrics()` — L0 files, compactions, WAL bytes |
@@ -255,31 +262,42 @@ falls back to silence.
 
 #### Known concerns (decide before v0.x freeze)
 
-1. **`kind` label explosion**: `EventsReceived{kind}` and
-   `EventsStored{kind, stored}` accept arbitrary `int64`. A malicious or
-   buggy client sending a unique kind per message would grow the series
-   set without bound. Candidate fixes (to be decided):
-   - **Allowlist of known kinds** (0, 1, 3, 4, 5, 6, 7, 40-44, 1984,
-     9734, 9735, 10000-19999, 30000-39999, …) with everything else
-     bucketed to `kind="other"`. Preserves per-kind fidelity for the
-     common case.
-   - **Range buckets** aligned with NIP-01 categories: `regular`,
-     `replaceable`, `ephemeral`, `addressable`, `other`. Loses per-kind
-     detail but cardinality is fixed at 5.
-   - **Drop the `kind` label entirely** and recover kind-level breakdown
-     from the event log instead.
+1. **`kind` label explosion** — **decided: known-kind allowlist.**
+   `EventsReceived{kind}` and `EventsStored{kind, stored}` accept
+   arbitrary `int64`; a hostile or buggy client sending a unique kind
+   per message would grow the series set without bound. The chosen
+   mitigation is an allowlist of well-known kinds (0, 1, 3, 4, 5, 6, 7,
+   40-44, 1984, 9734, 9735, 10000-19999, 30000-39999, …) with everything
+   else bucketed to `kind="other"`. This keeps per-kind fidelity for the
+   common case (kind 1 / 7 in particular are worth watching) while
+   holding cardinality bounded. Implementation is a follow-up PR.
+   Alternatives considered and rejected: NIP-01 range buckets
+   (`regular` / `replaceable` / `ephemeral` / `addressable` / `other` —
+   loses per-kind detail), and dropping the label entirely (recoverable
+   from the event log but inconvenient for dashboards / alerts).
 
-2. **Per-middleware counter alignment**: today `RejectionsTotal` lives on
-   `AuthMetrics` with two reasons. The follow-up should promote this to a
-   relay-wide `mocrelay_rejections_total{middleware, reason}` so every
-   `logRejection` call has a matching metric increment and the
-   `{middleware, reason}` cross-product stays a closed enum.
+2. **Per-middleware counter scope** — **decided: stay per-middleware.**
+   An earlier draft proposed promoting `RejectionsTotal` from
+   `AuthMetrics` to a relay-wide `mocrelay_rejections_total{middleware,
+   reason}`. We chose instead to keep each middleware's rejection
+   counter as its own metric (e.g. `mocrelay_auth_rejections_total`,
+   `mocrelay_max_content_length_rejections_total`, …). Rationale:
+   (a) it matches the existing per-middleware `*Metrics` / `*Options`
+   surface, so nil-safe injection stays local to each middleware;
+   (b) middlewares remain independent — adding or removing one doesn't
+   touch the others' label spaces; (c) each middleware's `reason` enum
+   stays small and closed, with no risk of colliding with another
+   middleware's vocabulary. The `{middleware, reason}` cross-product
+   view is still recoverable at query time via, e.g.,
+   `sum by(reason)({__name__=~"mocrelay_.*_rejections_total"})` —
+   PromQL is expressive enough that storage-layer independence doesn't
+   cost us aggregation at the query layer.
 
 3. **Pebble / Bleve internals**: `pebble.Metrics()` returns rich
-   saturation signals (L0 files, pending compactions, WAL bytes) that are
-   not exposed today. The usual pattern is a periodic collector goroutine
-   reading `Metrics()` every N seconds into Gauges. Out of scope for the
-   initial policy PR.
+   saturation signals (L0 files, pending compactions, WAL bytes) that
+   are not exposed today. The usual pattern is a periodic collector
+   goroutine reading `Metrics()` every N seconds into Gauges. Out of
+   scope for the initial policy PR; planned as a later follow-up.
 
 ### Design Decisions
 


### PR DESCRIPTION
## Summary

First-cut policy for Prometheus metrics, parallel to the existing Logging section in CLAUDE.md. **No code changes** — drafting the shape first so later metric additions have stable ground to grow into.

### What's in the policy

- **Framing: RED and USE** — RED (Rate / Errors / Duration) for request-driven paths, USE (Utilization / Saturation / Errors) for resources. Used together, not interchangeably: a request path can be slow *because* a resource is saturated, and you need both axes to see causation.
- **Cardinality rules** — `pubkey` / `conn_id` / `sub_id` / `ip` / `event_id` / free-form strings forbidden; `kind` flagged as risky (arbitrary `int64` accepted today); stable enums (`type` / `reason` / `result` / `middleware`) safe.
- **Layer convention** — count *received* at the outer Relay edge, *accepted* at the inner Storage edge; the difference is what middleware rejected, broken down per middleware.
- **Log ↔ metric cross-index** — every `logRejection` call gets a matching `rejections_total{middleware, reason}` with the same `reason` string. Today only `AuthMiddleware` does this; unifying the rest is the primary follow-up.
- **Instrument choice** — Counter cheap on every message, Gauge requires matched Inc/Dec, Histogram only where tail latency matters and buckets are audited.
- **Nil-safe injection** — metrics wired via `*Options`, mirroring `Relay.Logger`. `Metrics == nil` means "don't measure, don't allocate."
- **Coverage by layer** — table mapping existing 12 metrics to RED/USE and listing the gaps (unified middleware rejections, MergeHandler saturation, Pebble / Bleve internals) for future PRs.

### Known concerns (to decide before v0.x freeze)

1. **`kind` label explosion** on `EventsReceived` / `EventsStored` — candidates listed (allowlist, NIP-01 range buckets, drop the label).
2. **Per-middleware counter alignment** — promote `RejectionsTotal` from `AuthMetrics` to a relay-wide `rejections_total{middleware, reason}`.
3. **Pebble / Bleve internals** via `pebble.Metrics()` + periodic collector goroutine.

## Test plan

- [x] `git diff --stat` — only `CLAUDE.md` touched, +115 / -0
- [x] lefthook pre-commit — skipped (no matching staged files)
- [ ] Human review of the policy wording; tweak wording / table rows as needed before merge

🌱 Generated with [Claude Code](https://claude.com/claude-code)