### PR TITLE
feat: unified rejection metrics via ctx, auto-wired through logRejection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,25 +206,33 @@ review time, the label is probably too cardinal.
   wire, before middleware. This is the rate the relay is being offered.
 - **Inner (Storage / MergeHandler accepted path)**: count everything
   *accepted*. This is what actually took effect.
-- **Difference = amount rejected by middleware.** Each middleware emits
-  its own `<middleware>_rejections_total{reason}` counter (one metric
-  name per middleware, not a shared `{middleware, reason}` dimension),
-  so the breakdown is visible by cause while each middleware's metric
-  surface stays independent.
+- **Difference = amount rejected by middleware.** The breakdown by
+  cause is visible on the unified counter
+  `mocrelay_rejections_total{middleware, reason}` — every middleware
+  contributes to the same metric via [logRejection], distinguished by
+  the `middleware` label. See Known concerns #2 for why this shape
+  (rather than one metric per middleware) was chosen.
 
 #### Log ↔ metric cross-index
 
-Every middleware that calls `logRejection` also increments its own
-rejection counter, carrying the **same `reason` string** as a label. The
-shared key is the `reason` value, not a unified metric name:
+`logRejection` is the single place where every middleware reports a
+rejection. It performs two side-effects from the same call site:
+
+1. Increments `mocrelay_rejections_total{middleware, reason}` via the
+   context-injected [RejectionMetrics] (no-op if absent).
+2. Emits a Debug-level structured log entry with the same `middleware`
+   and `reason` fields.
+
+Because the two sinks share the exact label/field strings, the
+following queries target the same events:
 
 ```
-grep reason=max_content_length relay.log
-rate({__name__=~"mocrelay_.*_rejections_total", reason="max_content_length"}[5m])
+grep 'reason=max_content_length' relay.log
+rate(mocrelay_rejections_total{reason="max_content_length"}[5m])
 ```
 
-should land on the same events. Today only `AuthMiddleware` is wired —
-extending to all middleware is the primary follow-up.
+The `middleware` axis lets operators scope further:
+`sum by(reason) (mocrelay_rejections_total{middleware="auth"})`.
 
 #### Instrument choice
 
@@ -236,13 +244,31 @@ extending to all middleware is the primary follow-up.
 
 #### Nil-safe injection
 
-Metrics are optional, matching the philosophy of `Relay.Logger`. Each of
-`RelayMetrics`, `RouterMetrics`, `AuthMetrics`, `StorageMetrics` is passed
-through `*Options`; `nil` means "don't measure, don't allocate." Call
-sites guard with a nil check (or a no-op shim) so the instrument-free
-build path has zero runtime cost and no Prometheus dependency surface.
-Just as `Logger == nil` falls back to `slog.Default()`, `Metrics == nil`
-falls back to silence.
+Metrics are optional, matching the philosophy of `Relay.Logger`. Two
+injection shapes coexist:
+
+- **Per-owner options** (`RelayMetrics`, `RouterMetrics`, `AuthMetrics`,
+  `StorageMetrics`): passed through the owning type's `*Options` struct.
+  `nil` means "don't measure, don't allocate." Call sites guard with a
+  nil check so the instrument-free build path has zero runtime cost and
+  no Prometheus dependency surface.
+- **Context-injected** (`RejectionMetrics`): threaded through the
+  request context, symmetric with `Logger`. `Relay` installs it once
+  per connection; middleware never holds a reference, never needs a
+  nil check — `logRejection` reads it via `RejectionMetricsFromContext`
+  and no-ops on nil. This keeps the per-middleware API surface minimal
+  (no per-middleware metrics field just for rejections) and keeps
+  rejection reporting lazily DRY: a new middleware that calls
+  `logRejection` is automatically observable on day one.
+
+Just as `Logger == nil` falls back to `slog.Default()`, both
+`Metrics == nil` and a ctx without `RejectionMetrics` fall back to
+silence.
+
+A natural future step is to migrate the remaining `*Metrics` types onto
+the context-injected shape so that the whole metrics surface matches
+the `Logger` pattern, but that's deferred until a second metric
+(beyond rejections) is shown to benefit from ctx scope.
 
 #### Coverage by layer (drives follow-up PRs)
 
@@ -253,8 +279,8 @@ falls back to silence.
 | | RED-D | — | `ws_write_duration_seconds` (diagnose write timeouts) |
 | | USE-Sat | `ConnectionsCurrent` | `send_buf_full_drops_total`, `write_timeouts_total` |
 | **Router** | USE-Sat | `MessagesDropped` | `subscriptions_current` (Gauge) |
-| **Middleware: Auth** | RED-R+E | `AuthTotal{result}`, `RejectionsTotal{reason}`, `AuthenticatedConnectionsCurrent` | — |
-| **Middleware: others (11)** | RED-E | — | Per-middleware `<name>_rejections_total{reason}`, aligned with `logRejection` |
+| **Middleware: Auth** | RED-R+E | `AuthTotal{result}`, `AuthenticatedConnectionsCurrent`, rejections via unified `mocrelay_rejections_total{middleware="auth", reason}` | — |
+| **Middleware: others (10)** | RED-E | Rejections via unified `mocrelay_rejections_total{middleware, reason}` (wired automatically through `logRejection`) | — |
 | **StorageHandler** | RED-R+D | `EventsStored{kind, type, stored}`, `Store / QueryDuration` | `store_errors_total`, `query_errors_total` |
 | **MergeHandler** | USE-Sat+E | — | `lost_children_total`, `broadcast_timeouts_total`, `event_sort_drops_total` |
 | **Pebble (internals)** | USE | — | Expose `pebble.Metrics()` — L0 files, compactions, WAL bytes |
@@ -298,22 +324,38 @@ falls back to silence.
    overhead not justified given the fixed NIP mapping). Adjust the
    allowlist based on operational experience.
 
-2. **Per-middleware counter scope** — **decided: stay per-middleware.**
-   An earlier draft proposed promoting `RejectionsTotal` from
-   `AuthMetrics` to a relay-wide `mocrelay_rejections_total{middleware,
-   reason}`. We chose instead to keep each middleware's rejection
-   counter as its own metric (e.g. `mocrelay_auth_rejections_total`,
-   `mocrelay_max_content_length_rejections_total`, …). Rationale:
-   (a) it matches the existing per-middleware `*Metrics` / `*Options`
-   surface, so nil-safe injection stays local to each middleware;
-   (b) middlewares remain independent — adding or removing one doesn't
-   touch the others' label spaces; (c) each middleware's `reason` enum
-   stays small and closed, with no risk of colliding with another
-   middleware's vocabulary. The `{middleware, reason}` cross-product
-   view is still recoverable at query time via, e.g.,
-   `sum by(reason)({__name__=~"mocrelay_.*_rejections_total"})` —
-   PromQL is expressive enough that storage-layer independence doesn't
-   cost us aggregation at the query layer.
+2. **Rejection counter scope** — **implemented: unified
+   `mocrelay_rejections_total{middleware, reason}`.** A previous draft
+   of this policy argued for keeping one `<name>_rejections_total`
+   metric per middleware. In practice that shape required ten new
+   `*Options` structs and ~30 call-site updates across examples and
+   tests for the initial roll-out, so the convenience trade flipped:
+   a single counter with `{middleware, reason}` labels gives the same
+   observability with dramatically less surface area. Labels are a
+   functional pair (each middleware emits a fixed, small enum of
+   reasons), so the label set is bounded and does not form a true
+   cross-product — the same argument as Known concern #1's
+   `(kind, type)` two-axis label.
+
+   Implementation:
+   - `RejectionMetrics` lives in `metrics.go`; it wraps a single
+     `mocrelay_rejections_total` CounterVec.
+   - `Relay` installs it into the request context via
+     `ContextWithRejectionMetrics`, symmetric with `ContextWithLogger`.
+   - `logRejection` reads it from context on every call and increments
+     `{middleware, reason}` alongside its Debug log line. Middleware
+     authors don't touch metrics code at all.
+   - `AuthMetrics.RejectionsTotal` was removed as part of this pivot;
+     its auth-specific reasons (`event_unauthenticated`, `expired`, …)
+     now land on the unified counter with `middleware="auth"`.
+
+   Rejected alternatives: per-middleware `*Options` with a `Metrics`
+   field (API bloat across 10 middleware, constructor signature churn
+   propagated to every call site, little benefit since the reason
+   enums never collide once the `middleware` label is present);
+   removing the rejection counter entirely in favour of log-only
+   observability (forces operators to run log aggregators for basic
+   rate questions and loses the cheap Prometheus alert surface).
 
 3. **Pebble / Bleve internals**: `pebble.Metrics()` returns rich
    saturation signals (L0 files, pending compactions, WAL bytes) that

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/logger.go
+++ b/logger.go
@@ -21,15 +21,25 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 	return slog.Default()
 }
 
-// logRejection logs a middleware-level message rejection at Debug level with
-// a uniform key set. All middleware drops in mocrelay call this helper so
-// operators can find them with a single grep of "message rejected".
+// logRejection reports a middleware-level message rejection with a uniform
+// key set. It performs two side-effects:
+//
+//  1. Increments the unified [RejectionMetrics] counter from the context
+//     (labels {middleware, reason}) if one is installed. No-op if absent.
+//  2. Emits a Debug-level structured log entry ("message rejected") so
+//     operators can find all rejections with a single grep.
+//
+// Both sinks share the middleware and reason strings, making logs and
+// metrics cross-indexable by the reason label.
 //
 // Rejections are Debug (not Warn) because they are an expected outcome of
 // normal middleware policy and would otherwise flood the log. Enable Debug
 // logging when investigating why a specific client's messages are being
-// dropped.
+// dropped; rely on the metrics counter for day-to-day trends.
 func logRejection(ctx context.Context, middleware, reason string, attrs ...any) {
+	if m := RejectionMetricsFromContext(ctx); m != nil {
+		m.Total.WithLabelValues(middleware, reason).Inc()
+	}
 	base := []any{"middleware", middleware, "reason", reason}
 	LoggerFromContext(ctx).DebugContext(ctx, "message rejected", append(base, attrs...)...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestLoggerFromContext(t *testing.T) {
@@ -67,6 +70,65 @@ func TestLogRejection(t *testing.T) {
 
 		if buf.Len() != 0 {
 			t.Errorf("expected no output at Info level, got: %s", buf.String())
+		}
+	})
+
+	t.Run("increments rejection counter from ctx", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		metrics := NewRejectionMetrics(reg)
+		ctx := ContextWithRejectionMetrics(context.Background(), metrics)
+
+		logRejection(ctx, "max_content_length", "content_too_long",
+			"event_id", "abc", "length", 9999,
+		)
+		logRejection(ctx, "max_content_length", "content_too_long",
+			"event_id", "def", "length", 9999,
+		)
+		logRejection(ctx, "auth", "event_unauthenticated",
+			"event_id", "ghi",
+		)
+
+		if got := testutil.ToFloat64(metrics.Total.WithLabelValues(
+			"max_content_length", "content_too_long",
+		)); got != 2 {
+			t.Errorf("max_content_length/content_too_long: want 2, got %v", got)
+		}
+		if got := testutil.ToFloat64(metrics.Total.WithLabelValues(
+			"auth", "event_unauthenticated",
+		)); got != 1 {
+			t.Errorf("auth/event_unauthenticated: want 1, got %v", got)
+		}
+	})
+
+	t.Run("no-op when no metrics in ctx", func(t *testing.T) {
+		// Plain context.Background() — no RejectionMetrics installed.
+		// Should not panic and should still log.
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+		ctx := ContextWithLogger(context.Background(), logger)
+
+		logRejection(ctx, "auth", "event_unauthenticated", "event_id", "x")
+
+		if buf.Len() == 0 {
+			t.Error("expected log output, got none")
+		}
+	})
+}
+
+func TestRejectionMetricsFromContext(t *testing.T) {
+	t.Run("returns nil when not set", func(t *testing.T) {
+		if got := RejectionMetricsFromContext(context.Background()); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("returns metrics from context", func(t *testing.T) {
+		metrics := NewRejectionMetrics(prometheus.NewRegistry())
+		ctx := ContextWithRejectionMetrics(context.Background(), metrics)
+		if got := RejectionMetricsFromContext(ctx); got != metrics {
+			t.Fatalf("expected same metrics, got %v", got)
 		}
 	})
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,8 @@
 package mocrelay
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -71,10 +73,14 @@ func NewRouterMetrics(reg prometheus.Registerer) *RouterMetrics {
 }
 
 // AuthMetrics holds Prometheus metrics for AuthMiddleware.
+//
+// Rejection metrics are not part of this struct. They are unified across all
+// middleware under [RejectionMetrics] and are wired automatically via
+// [logRejection] — Auth contributes to the shared counter with label
+// middleware="auth".
 type AuthMetrics struct {
 	AuthTotal                       *prometheus.CounterVec
 	AuthenticatedConnectionsCurrent prometheus.Gauge
-	RejectionsTotal                 *prometheus.CounterVec
 }
 
 // NewAuthMetrics creates and registers AuthMiddleware metrics with the given registry.
@@ -88,19 +94,70 @@ func NewAuthMetrics(reg prometheus.Registerer) *AuthMetrics {
 			Name: "mocrelay_auth_authenticated_connections_current",
 			Help: "Current number of authenticated WebSocket connections",
 		}),
-		RejectionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "mocrelay_auth_rejections_total",
-			Help: "Total number of rejected messages due to missing authentication",
-		}, []string{"reason"}),
 	}
 
 	reg.MustRegister(
 		m.AuthTotal,
 		m.AuthenticatedConnectionsCurrent,
-		m.RejectionsTotal,
 	)
 
 	return m
+}
+
+// RejectionMetrics holds the unified rejection counter shared across every
+// middleware in mocrelay. Each middleware reports its rejections through
+// [logRejection], which increments this counter with labels
+// {middleware, reason} — the same pair that appears in the structured log
+// entry, so logs and metrics are cross-indexable.
+//
+// The (middleware, reason) pair is a functional relationship (each middleware
+// emits a fixed, small enum of reasons), so the label set is bounded and
+// does not form a cardinality cross-product — analogous to the (kind, type)
+// two-axis label on [RelayMetrics.EventsReceived].
+//
+// RejectionMetrics is injected into the request context by [Relay] (via
+// [RelayOptions.RejectionMetrics]); middleware code never holds a reference
+// and never needs a nil check — [logRejection] handles both.
+type RejectionMetrics struct {
+	Total *prometheus.CounterVec
+}
+
+// NewRejectionMetrics creates and registers the unified rejection counter
+// with the given registry.
+func NewRejectionMetrics(reg prometheus.Registerer) *RejectionMetrics {
+	m := &RejectionMetrics{
+		Total: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "mocrelay_rejections_total",
+			Help: "Total number of client messages rejected by middleware, " +
+				"labeled by the rejecting middleware and the reason. " +
+				"The reason label aligns with the structured log field " +
+				"emitted by logRejection, so logs and metrics share a key.",
+		}, []string{"middleware", "reason"}),
+	}
+
+	reg.MustRegister(m.Total)
+
+	return m
+}
+
+type rejectionMetricsKey struct{}
+
+// ContextWithRejectionMetrics returns a new context carrying the given
+// rejection metrics. [Relay] installs this at connection start so middleware
+// downstream can report rejections via [logRejection] without holding a
+// direct reference.
+func ContextWithRejectionMetrics(ctx context.Context, m *RejectionMetrics) context.Context {
+	return context.WithValue(ctx, rejectionMetricsKey{}, m)
+}
+
+// RejectionMetricsFromContext returns the rejection metrics from the context,
+// or nil if none was set. Callers (in practice only [logRejection]) must be
+// nil-safe.
+func RejectionMetricsFromContext(ctx context.Context) *RejectionMetrics {
+	if m, ok := ctx.Value(rejectionMetricsKey{}).(*RejectionMetrics); ok {
+		return m
+	}
+	return nil
 }
 
 // StorageMetrics holds Prometheus metrics for Storage.

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -104,9 +104,6 @@ func (m *authMiddleware) HandleClientMsg(
 
 	case MsgTypeEvent:
 		if !m.isAuthedPubkey(state, msg.Event.Pubkey) {
-			if m.metrics != nil {
-				m.metrics.RejectionsTotal.WithLabelValues("event_unauthenticated").Inc()
-			}
 			logRejection(ctx, "auth", "event_unauthenticated",
 				"event_id", msg.Event.ID,
 				"pubkey", msg.Event.Pubkey,
@@ -121,9 +118,6 @@ func (m *authMiddleware) HandleClientMsg(
 
 	case MsgTypeReq:
 		if !m.isAuthed(state) {
-			if m.metrics != nil {
-				m.metrics.RejectionsTotal.WithLabelValues("req_unauthenticated").Inc()
-			}
 			logRejection(ctx, "auth", "req_unauthenticated",
 				"sub_id", msg.SubscriptionID,
 			)

--- a/relay.go
+++ b/relay.go
@@ -26,6 +26,7 @@ type Relay struct {
 	pingTimeout      time.Duration
 	info             *RelayInfo
 	metrics          *RelayMetrics
+	rejectionMetrics *RejectionMetrics
 	connIDFunc       func() string
 
 	mu      sync.Mutex
@@ -65,6 +66,13 @@ type RelayOptions struct {
 	// Metrics is the Prometheus metrics collector.
 	// If set, the relay will collect connection and message metrics.
 	Metrics *RelayMetrics
+
+	// RejectionMetrics is the unified rejection counter shared across every
+	// middleware. If set, the relay installs it into the request context so
+	// that logRejection (called from every middleware drop) auto-increments
+	// the counter alongside its structured log entry. If nil, rejections are
+	// only logged — no counter is incremented.
+	RejectionMetrics *RejectionMetrics
 
 	// ConnIDFunc generates a unique connection ID string.
 	// If nil, a default monotonic counter ("1", "2", ...) is used.
@@ -106,6 +114,7 @@ func NewRelay(handler Handler, opts *RelayOptions) *Relay {
 		pingTimeout:      pingTimeout,
 		info:             opts.Info,
 		metrics:          opts.Metrics,
+		rejectionMetrics: opts.RejectionMetrics,
 		connIDFunc:       opts.ConnIDFunc,
 	}
 }
@@ -218,6 +227,9 @@ func (r *Relay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx = contextWithConnID(ctx, connID)
 	logger := r.logger.With("conn_id", connID)
 	ctx = ContextWithLogger(ctx, logger)
+	if r.rejectionMetrics != nil {
+		ctx = ContextWithRejectionMetrics(ctx, r.rejectionMetrics)
+	}
 
 	// Metrics: connection tracking
 	if r.metrics != nil {


### PR DESCRIPTION
## Summary

- **Pivot from per-middleware counters to a single `mocrelay_rejections_total{middleware, reason}`**, injected through the request context and auto-incremented from `logRejection`. Middleware authors don't touch metrics code at all — calling `logRejection` is enough.
- **Drops `AuthMetrics.RejectionsTotal`** (breaking, v0). Auth-specific reasons (`event_unauthenticated`, `req_unauthenticated`, `expired`, …) now land on the unified counter with `middleware="auth"`.
- **Zero changes in the other 10 middleware**: they already call `logRejection`; metrics now flow for free.
- **CLAUDE.md** Metrics policy updated to reflect the pivot, including a rewritten Known concerns #2 and a note on the future direction of migrating the remaining `*Metrics` types onto the same ctx-injection shape.

## Why the pivot

The original policy (PR #65) named per-middleware rejection counters as the "primary follow-up." When we started to implement it, the cost surfaced:

- 10 new `*Options` structs
- 11 constructor signature changes
- ~30 call-site updates across examples, tests, and doc comments

The alternative — a single counter labelled by `{middleware, reason}` — gives the same observability (`sum by(reason)` / `sum by(middleware)`) with:

- 1 new metric type
- 0 middleware constructor changes
- 0 call-site churn

`(middleware, reason)` is a functional pair (each middleware emits a fixed small enum of reasons), so the label set is bounded and does not form a true cross-product — the same argument that justified Known concerns #1's `(kind, type)` two-axis label.

## Why the ctx injection shape (not `*Options.Metrics`)

Symmetric with `Logger`: `Relay` installs the counter once per connection via `ContextWithRejectionMetrics`, and `logRejection` reads it through `RejectionMetricsFromContext`. This means:

- No per-middleware metrics field just for rejections
- A new middleware that calls `logRejection` is observable on day one
- Nil-safety is centralized in one place (`logRejection` handles it)

`AuthMetrics` keeps the per-owner options shape for its auth-specific signals (`AuthTotal`, `AuthenticatedConnectionsCurrent`). The two shapes are documented in CLAUDE.md's "Nil-safe injection" section, with a note that migrating the remaining `*Metrics` onto ctx-injection is a plausible future step.

## Test plan

- [x] `go vet ./...` green
- [x] `go test ./...` green (logger_test adds: counter increments from ctx, no-op when ctx has no metrics, `RejectionMetricsFromContext` helper)
- [x] No call-site changes in the 10 non-auth middleware — verified by `git diff --stat`
- [x] CLAUDE.md policy section consistent with the implementation

🌸 Generated with [Claude Code](https://claude.com/claude-code)