### PR TITLE
refactor: caller-owned *pebble.DB and bleve.Index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ slog.WarnContext(ctx, "query error", "error", err)
 |---|---|---|
 | **Error** | Data loss / corruption; operator must act now. | Storage.Store failure, unrecoverable I/O. |
 | **Warn** | Unexpected / externally-caused failures; individually tolerable but worth watching. | WebSocket parse / verify failure, MergeHandler lost child (timeout / early close), child handler returned error, Shutdown deadline exceeded. |
-| **Info** | Structural lifecycle events — one per connection or per relay, not per message. | Connection start / end, PebbleStorage / BleveIndex open / close, Relay shutdown progress. |
+| **Info** | Structural lifecycle events — one per connection or per relay, not per message. | Connection start / end, Relay shutdown progress. |
 | **Debug** | Hot-path events: every accepted EVENT, every REQ, every middleware rejection, every dropped broadcast. Off in production. | `logRejection` output, routerHandler per-message events, MergeHandler EVENT drop. |
 
 Rule of thumb: if the log fires "at Info or higher and would be noisy in
@@ -283,8 +283,8 @@ the `Logger` pattern, but that's deferred until a second metric
 | **Middleware: others (10)** | RED-E | Rejections via unified `mocrelay_rejections_total{middleware, reason}` (wired automatically through `logRejection`) | — |
 | **StorageHandler** | RED-R+D+E | `EventsStored{kind, type, stored}`, `Store / QueryDuration`, `StoreErrors`, `QueryErrors` | — |
 | **MergeHandler** | USE-Sat+E | `LostChildrenTotal`, `BroadcastTimeoutsTotal`, `EventDrops{reason}` | — |
-| **Pebble (internals)** | USE | — | Expose `pebble.Metrics()` — L0 files, compactions, WAL bytes |
-| **Bleve** | RED-R+D+E | — | `search_total`, `search_duration_seconds`, `search_errors_total` |
+| **Pebble (internals)** | USE | — (caller-owned) | External: expose via caller's `*pebble.DB` — `db.Metrics()` → L0 files, compactions, WAL bytes |
+| **Bleve** | RED-R+D+E | — (caller-owned) | External: expose via caller's `bleve.Index` — `idx.StatsMap()` / wrap `Search` for latency. Request-path RED could still be added inside mocrelay if operators want it without the caller ceremony. |
 
 Notes on retracted gaps:
 
@@ -376,11 +376,21 @@ Notes on retracted gaps:
    observability (forces operators to run log aggregators for basic
    rate questions and loses the cheap Prometheus alert surface).
 
-3. **Pebble / Bleve internals**: `pebble.Metrics()` returns rich
-   saturation signals (L0 files, pending compactions, WAL bytes) that
-   are not exposed today. The usual pattern is a periodic collector
-   goroutine reading `Metrics()` every N seconds into Gauges. Out of
-   scope for the initial policy PR; planned as a later follow-up.
+3. **Pebble / Bleve internals — exposed by the caller, not by
+   mocrelay.** `*pebble.DB` and `bleve.Index` are passed in by the
+   caller (see the "Caller-owned `*pebble.DB`" section), so
+   `db.Metrics()` — L0 files, pending compactions, WAL bytes — and
+   `idx.StatsMap()` live on the caller's side of the boundary. The
+   usual pattern is a periodic collector goroutine in the caller's
+   main reading these every N seconds into Gauges registered to the
+   same Prometheus registry that mocrelay's own metrics use. Putting
+   this inside mocrelay was the original plan, but it forced mocrelay
+   to (a) pin Pebble / Bleve versions tightly and (b) grow a new
+   "proxy every useful field" API surface for every new Pebble
+   release; moving the DB handle out eliminates both costs. Request-
+   path RED for Bleve search (latency / errors) *could* still be
+   added inside mocrelay later if operators want it without the
+   caller ceremony — see the Bleve row in the Coverage table.
 
 ### Design Decisions
 
@@ -389,12 +399,12 @@ Notes on retracted gaps:
 All public constructors in mocrelay follow a single shape:
 
 ```go
-NewX(required..., opts *XOptions) *X     // or (*X, error) for I/O
+NewX(required..., opts *XOptions) *X
 ```
 
 Rules:
 
-- **Positional args are required** (e.g. `handler`, `relayURL`, `path`).
+- **Positional args are required** (e.g. `handler`, `relayURL`, `db`).
   If a value has no sensible zero default, it goes here.
 - **Optional config lives in `*XOptions`** — one Options struct per type,
   right next to its constructor. `opts == nil` is always valid and means
@@ -817,30 +827,60 @@ Deletion markers:
 - Not supported in Pebble
 - Use separate search engine (Bleve, Meilisearch, etc.) via MergeHandler if needed
 
-**PebbleStorageOptions**:
-```go
-type PebbleStorageOptions struct {
-    CacheSize int64  // Block cache (default 8MB, production 64-256MB recommended)
-    FS        vfs.FS // For testing (vfs.NewMem())
-}
-```
+**Caller-owned `*pebble.DB`**:
 
-**Fixed settings (no need to change)**:
-- Bloom filter: 10 bits/key (~1% false positive), Table-level filter on all levels
-- MemTableSize: 4MB (~4000 events, sufficient for small-to-medium scale relays)
-- Other Pebble options: defaults are fine, add as needed
-
-**PebbleStorage Close**:
-- Caller responsible for `Close()` ("creator closes" principle)
-- Required to properly close WAL and files
+PebbleStorage does not open or close the Pebble database. The caller
+opens `*pebble.DB` with their own [pebble.Options] and passes it in:
 
 ```go
-storage, _ := NewPebbleStorage("/path/to/db", nil)
-defer storage.Close()  // ← Don't forget!
+db, err := pebble.Open("/path/to/db", &pebble.Options{
+    Cache:  pebble.NewCache(64 << 20), // 64 MB
+    Levels: bloomLevels,               // bloom filter per level
+    // EventListener, FormatMajorVersion, ... all caller's choice
+})
+if err != nil { ... }
+defer db.Close()  // ← caller closes the DB
 
+storage := NewPebbleStorage(db, nil) // no error, no Close()
 handler := NewStorageHandler(storage)
 relay := NewRelay(handler, nil)
 ```
+
+Consequences:
+
+- **PebbleStorage has no `Close()` method.** Lifecycle is the caller's.
+- **`PebbleStorageOptions` is currently empty** (reserved for future
+  use). Pass `nil`. DB-level tuning (cache size, bloom filter,
+  memtable size, event listeners, …) lives on `pebble.Options`, not on
+  PebbleStorageOptions.
+- **`db.Metrics()` is directly accessible to the caller**, so
+  Pebble-internal observability (L0 files, compaction debt, WAL bytes)
+  is exposed by the caller to their own Prometheus registry; mocrelay
+  no longer proxies it. See Coverage-by-layer note: the Pebble row is
+  "external — exposed via the caller's *pebble.DB".
+- **Pebble version** is the caller's choice too (MVS picks the highest
+  v1.x in the module graph; major-version differences would require
+  a `/v2` import path bump on mocrelay's side).
+
+**Recommended Pebble.Options for Nostr workloads** (not set by mocrelay;
+apply yourself if they fit your use case):
+
+- Bloom filter 10 bits/key (~1% false positive), table-level filter on
+  every level — significantly speeds up negative lookups on the
+  per-event-id index (`[0x01][event_id:32]`).
+- MemTableSize 4 MB — roughly 4000 events, adequate for small-to-medium
+  relays; raise it for write-heavy deployments.
+- Cache 64-256 MB in production, 8 MB (Pebble default) for dev.
+
+`BleveIndex` follows the same pattern: the caller opens the
+`bleve.Index` (typically with `mocrelay.BuildIndexMapping()`), passes
+it to `NewBleveIndex(idx, nil)`, and closes it themselves. `BleveIndex`
+has no `Close()`, and `BleveIndexOptions` is currently empty.
+`BuildIndexMapping()` is exported specifically because the Bleve
+mapping is part of the search semantics (CJK analyzer on `content`,
+keyword on `pubkey`, numeric on `kind` / `created_at`); callers who
+build their own index must use this mapping or Index/Search/Delete
+will operate on a different document shape.
 
 **Differential Testing**:
 - `storage_differential_test.go` verifies InMemory and Pebble behavior match

--- a/bleve_index.go
+++ b/bleve_index.go
@@ -2,7 +2,6 @@ package mocrelay
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis/lang/cjk"
@@ -20,66 +19,55 @@ type SearchIndex interface {
 
 	// Delete removes an event from the search index.
 	Delete(ctx context.Context, eventID string) error
-
-	// Close releases resources.
-	Close() error
 }
 
 // BleveIndex implements SearchIndex using Bleve with CJK analyzer.
+//
+// The [bleve.Index] is owned by the caller: BleveIndex does not open or
+// close it. Callers should create the index with [BuildIndexMapping] (or
+// a customized mapping built on top of it) so the document schema matches
+// what Index / Search / Delete expect, then close the underlying index
+// when done. BleveIndex itself has no Close method.
 type BleveIndex struct {
-	index  bleve.Index
-	logger *slog.Logger // For Open/Close/lifecycle logs (never nil; falls back to slog.Default()).
+	index bleve.Index
 }
 
-// BleveIndexOptions configures BleveIndex behavior.
-type BleveIndexOptions struct {
-	// Path to store the index. If empty, uses in-memory index.
-	Path string
+// BleveIndexOptions is reserved for future BleveIndex configuration.
+// It is currently empty but exists so that adding options later is not a
+// breaking API change. Pass nil for now.
+type BleveIndexOptions struct{}
 
-	// Logger is used for lifecycle events (Open, Close) that happen outside
-	// of any request context. Per-request errors continue to use the context
-	// logger via [LoggerFromContext].
-	// Default: [slog.Default]
-	Logger *slog.Logger
+// NewBleveIndex wraps an already-open [bleve.Index] as a [SearchIndex].
+//
+// The caller retains ownership of idx: they are responsible for opening it
+// (typically with [BuildIndexMapping]) and for closing it when done.
+// BleveIndex itself has no Close method.
+//
+// opts can be nil; there are currently no configurable options.
+func NewBleveIndex(idx bleve.Index, opts *BleveIndexOptions) *BleveIndex {
+	_ = opts // reserved for future use
+	return &BleveIndex{index: idx}
 }
 
-// NewBleveIndex creates a new Bleve-based search index.
-func NewBleveIndex(opts *BleveIndexOptions) (*BleveIndex, error) {
-	if opts == nil {
-		opts = &BleveIndexOptions{}
-	}
-
-	logger := opts.Logger
-	if logger == nil {
-		logger = slog.Default()
-	}
-
-	indexMapping := buildIndexMapping()
-
-	var index bleve.Index
-	var err error
-
-	if opts.Path == "" {
-		// In-memory index (for testing)
-		index, err = bleve.NewMemOnly(indexMapping)
-	} else {
-		// Try to open existing index, create if not exists
-		index, err = bleve.Open(opts.Path)
-		if err == bleve.ErrorIndexPathDoesNotExist {
-			index, err = bleve.New(opts.Path, indexMapping)
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if opts.Path == "" {
-		logger.Info("bleve index: opened (in-memory)")
-	} else {
-		logger.Info("bleve index: opened", "path", opts.Path)
-	}
-	return &BleveIndex{index: index, logger: logger}, nil
+// BuildIndexMapping returns the Bleve [mapping.IndexMappingImpl] that
+// BleveIndex expects. Use it when opening a [bleve.Index] to pass to
+// [NewBleveIndex]:
+//
+//	idx, _ := bleve.NewMemOnly(mocrelay.BuildIndexMapping())
+//	searchIndex := mocrelay.NewBleveIndex(idx, nil)
+//
+// It configures:
+//   - "content" as a text field analyzed with the CJK analyzer (bigram
+//     tokenization, covers Japanese / Chinese / Korean).
+//   - "id" as stored-only (indexed=false) so hits can be mapped back to
+//     event IDs without bloating the index.
+//   - "pubkey" as a keyword (exact match) field.
+//   - "kind" and "created_at" as numeric fields.
+//
+// Callers who need a customized mapping can build on top of the returned
+// value, but Index / Search / Delete rely on the document shape above.
+func BuildIndexMapping() *mapping.IndexMappingImpl {
+	return buildIndexMapping()
 }
 
 // buildIndexMapping creates the Bleve index mapping for Nostr events.
@@ -176,17 +164,6 @@ func (b *BleveIndex) Search(ctx context.Context, query string, limit int64) ([]s
 // Delete implements SearchIndex.Delete.
 func (b *BleveIndex) Delete(ctx context.Context, eventID string) error {
 	return b.index.Delete(eventID)
-}
-
-// Close implements SearchIndex.Close.
-func (b *BleveIndex) Close() error {
-	err := b.index.Close()
-	if err != nil {
-		b.logger.Warn("bleve index: close returned error", "error", err)
-	} else {
-		b.logger.Info("bleve index: closed")
-	}
-	return err
 }
 
 func (b *BleveIndex) docCount() (uint64, error) {

--- a/bleve_index_test.go
+++ b/bleve_index_test.go
@@ -5,17 +5,35 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/blevesearch/bleve/v2"
 )
+
+// openTestBleveIndex opens an in-memory Bleve index for tests and registers
+// a cleanup that closes it. Callers must not close the returned index
+// themselves.
+func openTestBleveIndex(t *testing.T) bleve.Index {
+	t.Helper()
+	idx, err := bleve.NewMemOnly(BuildIndexMapping())
+	if err != nil {
+		t.Fatalf("bleve.NewMemOnly failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = idx.Close()
+	})
+	return idx
+}
+
+// setupBleveIndex returns a BleveIndex wrapping an in-memory index.
+func setupBleveIndex(t *testing.T) *BleveIndex {
+	t.Helper()
+	return NewBleveIndex(openTestBleveIndex(t), nil)
+}
 
 func TestBleveIndex_IndexAndSearch(t *testing.T) {
 	ctx := context.Background()
 
-	// Create in-memory index
-	idx, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer idx.Close()
+	idx := setupBleveIndex(t)
 
 	// Index some events
 	events := []*Event{
@@ -82,11 +100,7 @@ func TestBleveIndex_IndexAndSearch(t *testing.T) {
 func TestBleveIndex_SearchLimit(t *testing.T) {
 	ctx := context.Background()
 
-	idx, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer idx.Close()
+	idx := setupBleveIndex(t)
 
 	// Index 20 events with similar content
 	for i := range 20 {
@@ -116,11 +130,7 @@ func TestBleveIndex_SearchLimit(t *testing.T) {
 func TestBleveIndex_Delete(t *testing.T) {
 	ctx := context.Background()
 
-	idx, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer idx.Close()
+	idx := setupBleveIndex(t)
 
 	// Index an event
 	e := &Event{
@@ -170,11 +180,7 @@ func TestBleveIndex_Delete(t *testing.T) {
 func TestBleveIndex_NilEvent(t *testing.T) {
 	ctx := context.Background()
 
-	idx, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer idx.Close()
+	idx := setupBleveIndex(t)
 
 	// Index nil event should not error
 	if err := idx.Index(ctx, nil); err != nil {

--- a/cmd/examples/kitchen-sink/main.go
+++ b/cmd/examples/kitchen-sink/main.go
@@ -25,6 +25,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/blevesearch/bleve/v2"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -56,27 +59,45 @@ func main() {
 	storageMetrics := mocrelay.NewStorageMetrics(reg)
 
 	// --- Storage layer ---
+	//
+	// mocrelay does not open or close the underlying Pebble / Bleve
+	// databases: the caller owns them. This lets callers pick their own
+	// pebble.Options (cache size, bloom filter, event listeners, ...),
+	// expose db.Metrics() to Prometheus themselves, and pin their own
+	// Pebble / Bleve versions independently of mocrelay's go.mod.
 
 	// Pebble: persistent LSM-tree storage.
-	pebbleStorage, err := mocrelay.NewPebbleStorage(
-		filepath.Join(dataDir, "pebble"),
-		&mocrelay.PebbleStorageOptions{
-			CacheSize: 64 * 1024 * 1024, // 64 MB block cache
+	cache := pebble.NewCache(64 << 20) // 64 MB block cache
+	defer cache.Unref()
+	bloomOpts := pebble.LevelOptions{
+		FilterPolicy: bloom.FilterPolicy(10),
+		FilterType:   pebble.TableFilter,
+	}
+	db, err := pebble.Open(filepath.Join(dataDir, "pebble"), &pebble.Options{
+		Cache: cache,
+		// Apply the bloom filter to every level (Pebble uses 7 by default).
+		Levels: []pebble.LevelOptions{
+			bloomOpts, bloomOpts, bloomOpts, bloomOpts,
+			bloomOpts, bloomOpts, bloomOpts,
 		},
-	)
+	})
 	if err != nil {
 		log.Fatalf("pebble: %v", err)
 	}
-	defer pebbleStorage.Close()
+	defer db.Close()
+	pebbleStorage := mocrelay.NewPebbleStorage(db, nil)
 
 	// Bleve: full-text search with CJK support (NIP-50).
-	bleveIndex, err := mocrelay.NewBleveIndex(&mocrelay.BleveIndexOptions{
-		Path: filepath.Join(dataDir, "bleve"),
-	})
+	blevePath := filepath.Join(dataDir, "bleve")
+	idx, err := bleve.Open(blevePath)
+	if err == bleve.ErrorIndexPathDoesNotExist {
+		idx, err = bleve.New(blevePath, mocrelay.BuildIndexMapping())
+	}
 	if err != nil {
 		log.Fatalf("bleve: %v", err)
 	}
-	defer bleveIndex.Close()
+	defer idx.Close()
+	bleveIndex := mocrelay.NewBleveIndex(idx, nil)
 
 	// Composite: Pebble (source of truth) + Bleve (search).
 	compositeStorage := mocrelay.NewCompositeStorage(pebbleStorage, bleveIndex)

--- a/composite_storage_test.go
+++ b/composite_storage_test.go
@@ -11,11 +11,7 @@ func TestCompositeStorage_StoreAndQuery(t *testing.T) {
 
 	// Create primary (InMemory) and search (Bleve)
 	primary := NewInMemoryStorage()
-	search, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer search.Close()
+	search := setupBleveIndex(t)
 
 	storage := NewCompositeStorage(primary, search)
 
@@ -192,11 +188,7 @@ func TestCompositeStorage_EphemeralNotIndexed(t *testing.T) {
 	ctx := context.Background()
 
 	primary := NewInMemoryStorage()
-	search, err := NewBleveIndex(nil)
-	if err != nil {
-		t.Fatalf("NewBleveIndex failed: %v", err)
-	}
-	defer search.Close()
+	search := setupBleveIndex(t)
 
 	storage := NewCompositeStorage(primary, search)
 

--- a/doc.go
+++ b/doc.go
@@ -55,14 +55,20 @@
 //	}
 //
 // [InMemoryStorage] is provided for testing. For production use, see [PebbleStorage]
-// which provides persistent storage using CockroachDB's Pebble LSM-tree engine.
+// which wraps a caller-owned CockroachDB Pebble LSM-tree [*pebble.DB].
+// Full-text search (NIP-50) is available via [BleveIndex], which wraps a
+// caller-owned [bleve.Index].
 //
 // # Typical usage
 //
-// A typical relay combines storage, routing, middleware, and metrics:
+// A typical relay combines storage, routing, middleware, and metrics.
+// The caller owns the underlying pebble.DB (and bleve.Index, if used),
+// which keeps [pebble.DB.Metrics] and database lifecycle in the caller's
+// hands:
 //
-//	storage, _ := NewPebbleStorage("/path/to/db", nil)
-//	defer storage.Close()
+//	db, _ := pebble.Open("/path/to/db", nil)
+//	defer db.Close()
+//	storage := NewPebbleStorage(db, nil)
 //
 //	router := NewRouter(nil)
 //	handler := NewMergeHandler(

--- a/pebble_storage.go
+++ b/pebble_storage.go
@@ -10,15 +10,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"iter"
-	"log/slog"
 	"math"
 	"sort"
 	"strconv"
 	"sync"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/bloom"
-	"github.com/cockroachdb/pebble/vfs"
 )
 
 // Key prefixes for Pebble storage
@@ -45,101 +42,33 @@ const (
 )
 
 // PebbleStorage implements Storage using Pebble (LSM-tree based KV store).
+//
+// The *pebble.DB is owned by the caller: PebbleStorage does not open or
+// close the database. The caller is responsible for opening the DB with
+// whatever [pebble.Options] are appropriate (cache size, bloom filters,
+// event listeners, etc.) and for closing it when done. This lets the
+// caller expose [pebble.DB.Metrics] directly and pin their own Pebble
+// version independent of mocrelay's go.mod.
 type PebbleStorage struct {
-	db     *pebble.DB
-	cache  *pebble.Cache // Keep reference to close on Close()
-	logger *slog.Logger  // For Open/Close/lifecycle logs (never nil; falls back to slog.Default()).
-	mu     sync.RWMutex  // For atomic operations spanning multiple keys
+	db *pebble.DB
+	mu sync.RWMutex // For atomic operations spanning multiple keys
 }
 
-// PebbleStorageOptions configures PebbleStorage behavior.
-type PebbleStorageOptions struct {
-	// CacheSize is the size of the block cache in bytes.
-	// Larger cache improves read performance by keeping frequently accessed
-	// SSTable blocks in memory.
-	// Default: 8MB (Pebble's default). Recommended: 64MB-256MB for production.
-	CacheSize int64
+// PebbleStorageOptions is reserved for future PebbleStorage configuration.
+// It is currently empty but exists so that adding options later is not a
+// breaking API change. Pass nil for now.
+type PebbleStorageOptions struct{}
 
-	// Logger is used for lifecycle events (Open, Close) that happen outside
-	// of any request context. Per-request errors (Store / Query) continue to
-	// use the context logger via [LoggerFromContext].
-	// Default: [slog.Default]
-	Logger *slog.Logger
-
-	// fs provides the interface for persistent file storage (unexported: test use only).
-	// Use vfs.NewMem() for in-memory storage.
-	// Default: vfs.Default (operating system's file system)
-	fs vfs.FS
-}
-
-// NewPebbleStorage creates a new Pebble-backed storage.
-// path is the directory where Pebble will store its data.
-// opts can be nil for default options.
-func NewPebbleStorage(path string, opts *PebbleStorageOptions) (*PebbleStorage, error) {
-	if opts == nil {
-		opts = &PebbleStorageOptions{}
-	}
-
-	logger := opts.Logger
-	if logger == nil {
-		logger = slog.Default()
-	}
-
-	// Configure Bloom filter for efficient negative lookups.
-	// 10 bits per key provides ~1% false positive rate.
-	levelOpts := pebble.LevelOptions{
-		FilterPolicy: bloom.FilterPolicy(10),
-		FilterType:   pebble.TableFilter, // Table-level filter (faster than block-level)
-	}
-
-	pebbleOpts := &pebble.Options{
-		// Apply Bloom filter to all levels (Pebble uses 7 levels by default)
-		Levels: []pebble.LevelOptions{
-			levelOpts, // L0
-			levelOpts, // L1
-			levelOpts, // L2
-			levelOpts, // L3
-			levelOpts, // L4
-			levelOpts, // L5
-			levelOpts, // L6
-		},
-	}
-
-	// Apply custom filesystem
-	if opts.fs != nil {
-		pebbleOpts.FS = opts.fs
-	}
-
-	// Apply custom cache size
-	var cache *pebble.Cache
-	if opts.CacheSize > 0 {
-		cache = pebble.NewCache(opts.CacheSize)
-		pebbleOpts.Cache = cache
-	}
-
-	db, err := pebble.Open(path, pebbleOpts)
-	if err != nil {
-		if cache != nil {
-			cache.Unref()
-		}
-		return nil, fmt.Errorf("open pebble database: %w", err)
-	}
-	logger.Info("pebble storage: opened", "path", path, "cache_size", opts.CacheSize)
-	return &PebbleStorage{db: db, cache: cache, logger: logger}, nil
-}
-
-// Close closes the Pebble database.
-func (s *PebbleStorage) Close() error {
-	err := s.db.Close()
-	if s.cache != nil {
-		s.cache.Unref()
-	}
-	if err != nil {
-		s.logger.Warn("pebble storage: close returned error", "error", err)
-	} else {
-		s.logger.Info("pebble storage: closed")
-	}
-	return err
+// NewPebbleStorage wraps an already-open *pebble.DB as a Storage.
+//
+// The caller retains ownership of db: they are responsible for opening it
+// (with their own [pebble.Options]) and for calling db.Close() when done.
+// PebbleStorage itself has no Close method.
+//
+// opts can be nil; there are currently no configurable options.
+func NewPebbleStorage(db *pebble.DB, opts *PebbleStorageOptions) *PebbleStorage {
+	_ = opts // reserved for future use
+	return &PebbleStorage{db: db}
 }
 
 // Store implements Storage.Store.

--- a/pebble_storage_test.go
+++ b/pebble_storage_test.go
@@ -4,19 +4,27 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func setupPebbleStorage(t *testing.T) *PebbleStorage {
+// openTestPebbleDB opens an in-memory Pebble DB for tests and registers a
+// cleanup that closes it. Callers must not close the returned DB themselves.
+func openTestPebbleDB(t *testing.T) *pebble.DB {
 	t.Helper()
-	dir := t.TempDir()
-	s, err := NewPebbleStorage(dir, nil)
+	db, err := pebble.Open("test", &pebble.Options{FS: vfs.NewMem()})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		s.Close()
+		_ = db.Close()
 	})
-	return s
+	return db
+}
+
+func setupPebbleStorage(t *testing.T) *PebbleStorage {
+	t.Helper()
+	return NewPebbleStorage(openTestPebbleDB(t), nil)
 }
 
 // queryPebble is a test helper that collects events from Query into a slice.

--- a/storage_differential_test.go
+++ b/storage_differential_test.go
@@ -9,7 +9,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,9 +30,7 @@ func testStorageDifferentialWithSeed(t *testing.T, seed uint64) {
 	// Create both storages
 	inMemory := NewInMemoryStorage()
 
-	pebbleStorage, err := NewPebbleStorage("test", &PebbleStorageOptions{fs: vfs.NewMem()})
-	require.NoError(t, err)
-	defer pebbleStorage.Close()
+	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	// Use deterministic random generator
 	rng := rand.New(rand.NewPCG(seed, seed))
@@ -186,9 +183,7 @@ func TestStorageDifferential_Kind5(t *testing.T) {
 	ctx := context.Background()
 
 	inMemory := NewInMemoryStorage()
-	pebbleStorage, err := NewPebbleStorage("test", &PebbleStorageOptions{fs: vfs.NewMem()})
-	require.NoError(t, err)
-	defer pebbleStorage.Close()
+	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	pubkey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -236,9 +231,7 @@ func TestStorageDifferential_Replaceable(t *testing.T) {
 	ctx := context.Background()
 
 	inMemory := NewInMemoryStorage()
-	pebbleStorage, err := NewPebbleStorage("test", &PebbleStorageOptions{fs: vfs.NewMem()})
-	require.NoError(t, err)
-	defer pebbleStorage.Close()
+	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	pubkey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -271,9 +264,7 @@ func TestStorageDifferential_Addressable(t *testing.T) {
 	ctx := context.Background()
 
 	inMemory := NewInMemoryStorage()
-	pebbleStorage, err := NewPebbleStorage("test", &PebbleStorageOptions{fs: vfs.NewMem()})
-	require.NoError(t, err)
-	defer pebbleStorage.Close()
+	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	pubkey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -330,9 +321,7 @@ func testStorageHandlerDifferentialWithSeed(t *testing.T, seed uint64) {
 
 	// Create both storages
 	inMemory := NewInMemoryStorage()
-	pebbleStorage, err := NewPebbleStorage("test", &PebbleStorageOptions{fs: vfs.NewMem()})
-	require.NoError(t, err)
-	defer pebbleStorage.Close()
+	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	// Create handlers
 	handlerInMem := NewStorageHandler(inMemory)


### PR DESCRIPTION
## Summary

Invert ownership of the Pebble and Bleve database handles: mocrelay no
longer opens or closes them. The caller opens `*pebble.DB` and
`bleve.Index` with their own options and passes the handle to
`NewPebbleStorage` / `NewBleveIndex`.

## Motivation

- **Metrics observability**. `db.Metrics()` / `idx.StatsMap()` now live
  on the caller's side, so Pebble / Bleve internals (L0 files,
  compaction debt, WAL bytes, …) can be exposed to Prometheus without
  mocrelay growing a proxy metric for every field upstream ships. This
  closes the Pebble / Bleve rows on the Metrics policy Coverage table
  by marking them "external — exposed via the caller's handle".
- **Tuning**. `pebble.Options` (cache size, bloom filters, event
  listener, format major version, …) and Bleve mapping customization
  move back to the caller where they belong.
- **Version coupling**. Callers can pin their own Pebble / Bleve
  versions within the same major — Go MVS picks the highest `v1.x`
  across the module graph, so mocrelay no longer dictates the exact
  version.

## Breaking changes

- `NewPebbleStorage(path string, opts) (*PebbleStorage, error)` →
  `NewPebbleStorage(db *pebble.DB, opts) *PebbleStorage`
- `NewBleveIndex(opts) (*BleveIndex, error)` →
  `NewBleveIndex(idx bleve.Index, opts) *BleveIndex`
- `(*PebbleStorage).Close()` and `(*BleveIndex).Close()` removed —
  the caller closes their own `db` / `idx`.
- `SearchIndex` interface no longer requires `Close()`.
- `PebbleStorageOptions.CacheSize` / `FS` and `BleveIndexOptions.Path` /
  `Logger` removed. Both `*Options` are now empty structs reserved for
  future use; pass `nil`.
- `BuildIndexMapping()` is **exported** so callers opening their own
  `bleve.Index` get the mapping `Index` / `Search` / `Delete` rely on
  (CJK analyzer on `content`, keyword `pubkey`, numeric `kind` /
  `created_at`). Customize on top if needed.

## Example

```go
db, err := pebble.Open("/path/to/db", &pebble.Options{
    Cache:  pebble.NewCache(64 << 20),
    Levels: bloomLevels, // bloom filter per level, per taste
})
if err != nil { log.Fatal(err) }
defer db.Close()
storage := mocrelay.NewPebbleStorage(db, nil)

idx, err := bleve.New("/path/to/bleve", mocrelay.BuildIndexMapping())
if err != nil { log.Fatal(err) }
defer idx.Close()
searchIdx := mocrelay.NewBleveIndex(idx, nil)
```

Full end-to-end usage in `cmd/examples/kitchen-sink/main.go`.

## Docs

`CLAUDE.md`:

- New "Caller-owned `*pebble.DB`" section documents the pattern,
  `PebbleStorageOptions` / `BleveIndexOptions` being empty, and the
  recommended Pebble options for Nostr workloads (bloom 10 bits/key,
  MemTableSize 4 MB, 64-256 MB cache).
- Metrics policy Coverage table updated: Pebble / Bleve rows marked
  "external (caller-owned)".
- Metrics Known concern #3 rewritten to reflect the new boundary and
  note that request-path RED for Bleve search could still be added
  inside mocrelay later if operators want it without the caller
  ceremony.
- Constructor API section's positional-arg example now includes `db`
  and drops the `(*X, error)` variant (no more I/O constructors).

`doc.go` typical-usage block updated to the new shape.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite including PebbleStorage, BleveIndex,
  CompositeStorage, storage_differential, MergeHandler / Router / Auth
  synctest paths) — green
- [x] `lefthook run pre-commit` — green
- [ ] `moctane-mocrelay` will need to adopt the new constructors
  (tracked separately; intended to follow by walking the mocrelay git
  log)

🎨 Generated with [Claude Code](https://claude.com/claude-code)