### PR TITLE
feat: expose search RED via CompositeStorageMetrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,8 @@ Metrics are optional, matching the philosophy of `Relay.Logger`. Two
 injection shapes coexist:
 
 - **Per-owner options** (`RelayMetrics`, `RouterMetrics`, `AuthMetrics`,
-  `StorageMetrics`, `MergeHandlerMetrics`): passed through the owning
+  `StorageMetrics`, `MergeHandlerMetrics`, `CompositeStorageMetrics`):
+  passed through the owning
   type's `*Options` struct. `nil` means "don't measure, don't allocate."
   Call sites guard with a nil check so the instrument-free build path
   has zero runtime cost and no Prometheus dependency surface.
@@ -284,7 +285,8 @@ the `Logger` pattern, but that's deferred until a second metric
 | **StorageHandler** | RED-R+D+E | `EventsStored{kind, type, stored}`, `Store / QueryDuration`, `StoreErrors`, `QueryErrors` | — |
 | **MergeHandler** | USE-Sat+E | `LostChildrenTotal`, `BroadcastTimeoutsTotal`, `EventDrops{reason}` | — |
 | **Pebble (internals)** | USE | — (caller-owned) | External: expose via caller's `*pebble.DB` — `db.Metrics()` → L0 files, compactions, WAL bytes |
-| **Bleve** | RED-R+D+E | — (caller-owned) | External: expose via caller's `bleve.Index` — `idx.StatsMap()` / wrap `Search` for latency. Request-path RED could still be added inside mocrelay if operators want it without the caller ceremony. |
+| **Bleve / SearchIndex (via CompositeStorage)** | RED-R+E | `SearchTotal`, `SearchErrors`, `IndexTotal`, `IndexErrors` (on `CompositeStorageMetrics`) | — |
+| | USE | — (caller-owned) | External: expose via caller's `bleve.Index` — `idx.StatsMap()` → doc count, batch stats |
 
 Notes on retracted gaps:
 
@@ -376,9 +378,9 @@ Notes on retracted gaps:
    observability (forces operators to run log aggregators for basic
    rate questions and loses the cheap Prometheus alert surface).
 
-3. **Pebble / Bleve internals — exposed by the caller, not by
-   mocrelay.** `*pebble.DB` and `bleve.Index` are passed in by the
-   caller (see the "Caller-owned `*pebble.DB`" section), so
+3. **Pebble / Bleve internals — USE is exposed by the caller, RED for
+   Bleve search is internal.** `*pebble.DB` and `bleve.Index` are passed
+   in by the caller (see the "Caller-owned `*pebble.DB`" section), so
    `db.Metrics()` — L0 files, pending compactions, WAL bytes — and
    `idx.StatsMap()` live on the caller's side of the boundary. The
    usual pattern is a periodic collector goroutine in the caller's
@@ -387,10 +389,30 @@ Notes on retracted gaps:
    this inside mocrelay was the original plan, but it forced mocrelay
    to (a) pin Pebble / Bleve versions tightly and (b) grow a new
    "proxy every useful field" API surface for every new Pebble
-   release; moving the DB handle out eliminates both costs. Request-
-   path RED for Bleve search (latency / errors) *could* still be
-   added inside mocrelay later if operators want it without the
-   caller ceremony — see the Bleve row in the Coverage table.
+   release; moving the DB handle out eliminates both costs.
+
+   Request-path RED for Bleve search (rate / errors) **has been added
+   inside mocrelay** on `CompositeStorage` via `CompositeStorageMetrics`:
+   `SearchTotal`, `SearchErrors`, `IndexTotal`, `IndexErrors`. These
+   instrument the two call sites where `CompositeStorage` would
+   otherwise silently swallow a backend failure — `Search` falls back
+   to the primary on error, and `Index` is fire-and-forget on the
+   success path of `Store`. Without these counters the search backend
+   could be fully broken (clients still see results, just not
+   search-scored) or the search index could silently drift out of sync
+   with the primary, and nobody would notice until a user complained.
+   Each failure is also logged at Warn via `LoggerFromContext(ctx)`
+   with matching fields (`event_id` / `query`, `error`) so logs and
+   metrics stay cross-indexable, mirroring the `logRejection` pattern.
+
+   Duration (RED-D) was deliberately not added on the search side: the
+   Bleve hop is dominated by `Search`'s own latency (primary
+   `IDs → Event` fetch is O(1) per ID), and that latency is already
+   captured inside `StorageMetrics.QueryDuration`. A separate
+   `SearchDuration` histogram would track the same shape; it can be
+   introduced later if a concrete operational need emerges (e.g.
+   isolating Bleve slowness from Pebble slowness when
+   `QueryDuration` spikes).
 
 ### Design Decisions
 
@@ -419,9 +441,10 @@ Rules:
   a post-construction field. Uniform with every other optional setting.
 
 This pattern is used by `NewRelay`, `NewRouter`, `NewAuthMiddlewareBase`,
-`NewPebbleStorage`, and `NewBleveIndex`. New Handlers / Middlewares /
-Storages added to mocrelay should follow the same shape so third-party
-code composing with mocrelay has a predictable surface.
+`NewPebbleStorage`, `NewBleveIndex`, and `NewCompositeStorage`. New
+Handlers / Middlewares / Storages added to mocrelay should follow the
+same shape so third-party code composing with mocrelay has a predictable
+surface.
 
 Exceptions:
 - `MetricsStorage` uses the decorator pattern (`NewMetricsStorage(storage, metrics)`)

--- a/cmd/examples/kitchen-sink/main.go
+++ b/cmd/examples/kitchen-sink/main.go
@@ -57,6 +57,7 @@ func main() {
 	routerMetrics := mocrelay.NewRouterMetrics(reg)
 	authMetrics := mocrelay.NewAuthMetrics(reg)
 	storageMetrics := mocrelay.NewStorageMetrics(reg)
+	compositeMetrics := mocrelay.NewCompositeStorageMetrics(reg)
 
 	// --- Storage layer ---
 	//
@@ -100,7 +101,9 @@ func main() {
 	bleveIndex := mocrelay.NewBleveIndex(idx, nil)
 
 	// Composite: Pebble (source of truth) + Bleve (search).
-	compositeStorage := mocrelay.NewCompositeStorage(pebbleStorage, bleveIndex)
+	compositeStorage := mocrelay.NewCompositeStorage(pebbleStorage, bleveIndex, &mocrelay.CompositeStorageOptions{
+		Metrics: compositeMetrics,
+	})
 
 	// Metrics: wrap storage with Prometheus instrumentation.
 	storage := mocrelay.NewMetricsStorage(compositeStorage, storageMetrics)

--- a/composite_storage.go
+++ b/composite_storage.go
@@ -16,18 +16,41 @@ import (
 // Store behavior:
 //   - Store in primary first (source of truth)
 //   - If successful, index in search index (best effort)
+//
+// Both the search path and the index path swallow their backend's errors
+// from the caller's perspective (search falls back to primary; index is
+// fire-and-forget). Wire [CompositeStorageOptions.Metrics] to make those
+// failures visible via [CompositeStorageMetrics.SearchErrors] /
+// [CompositeStorageMetrics.IndexErrors]; a structured Warn log is emitted
+// alongside each failure via [LoggerFromContext].
 type CompositeStorage struct {
 	primary Storage
 	search  SearchIndex
+	metrics *CompositeStorageMetrics
+}
+
+// CompositeStorageOptions configures [CompositeStorage]. Pass nil for
+// defaults.
+type CompositeStorageOptions struct {
+	// Metrics collects search and indexing observability signals. nil
+	// disables instrumentation (zero runtime cost, no Prometheus
+	// dependency on the caller).
+	Metrics *CompositeStorageMetrics
 }
 
 // NewCompositeStorage creates a new CompositeStorage.
 // primary is the source of truth for all data.
 // search provides full-text search capabilities (can be nil to disable search).
-func NewCompositeStorage(primary Storage, search SearchIndex) *CompositeStorage {
+// opts can be nil; see [CompositeStorageOptions] for configurable options.
+func NewCompositeStorage(primary Storage, search SearchIndex, opts *CompositeStorageOptions) *CompositeStorage {
+	var metrics *CompositeStorageMetrics
+	if opts != nil {
+		metrics = opts.Metrics
+	}
 	return &CompositeStorage{
 		primary: primary,
 		search:  search,
+		metrics: metrics,
 	}
 }
 
@@ -44,7 +67,19 @@ func (s *CompositeStorage) Store(ctx context.Context, event *Event) (bool, error
 	if s.search != nil && event != nil {
 		// Only index non-ephemeral events with content
 		if event.EventType() != EventTypeEphemeral && event.Content != "" {
-			_ = s.search.Index(ctx, event) // Ignore errors - primary is truth
+			if s.metrics != nil {
+				s.metrics.IndexTotal.Inc()
+			}
+			if ierr := s.search.Index(ctx, event); ierr != nil {
+				if s.metrics != nil {
+					s.metrics.IndexErrors.Inc()
+				}
+				LoggerFromContext(ctx).WarnContext(ctx,
+					"search index failed; primary store succeeded, index will drift",
+					"event_id", event.ID,
+					"error", ierr,
+				)
+			}
 		}
 	}
 
@@ -75,9 +110,20 @@ func (s *CompositeStorage) Query(ctx context.Context, filters []*ReqFilter) (ite
 	}
 
 	// Search for event IDs
+	if s.metrics != nil {
+		s.metrics.SearchTotal.Inc()
+	}
 	eventIDs, err := s.search.Search(ctx, searchQuery, limit)
 	if err != nil {
 		// Fall back to primary on search error
+		if s.metrics != nil {
+			s.metrics.SearchErrors.Inc()
+		}
+		LoggerFromContext(ctx).WarnContext(ctx,
+			"search backend failed; falling back to primary",
+			"query", searchQuery,
+			"error", err,
+		)
 		return s.primary.Query(ctx, filters)
 	}
 

--- a/composite_storage_test.go
+++ b/composite_storage_test.go
@@ -2,8 +2,13 @@ package mocrelay
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCompositeStorage_StoreAndQuery(t *testing.T) {
@@ -13,7 +18,7 @@ func TestCompositeStorage_StoreAndQuery(t *testing.T) {
 	primary := NewInMemoryStorage()
 	search := setupBleveIndex(t)
 
-	storage := NewCompositeStorage(primary, search)
+	storage := NewCompositeStorage(primary, search, nil)
 
 	// Store some events
 	events := []*Event{
@@ -143,7 +148,7 @@ func TestCompositeStorage_NoSearchIndex(t *testing.T) {
 
 	// Create composite without search index
 	primary := NewInMemoryStorage()
-	storage := NewCompositeStorage(primary, nil)
+	storage := NewCompositeStorage(primary, nil, nil)
 
 	// Store an event
 	event := &Event{
@@ -190,7 +195,7 @@ func TestCompositeStorage_EphemeralNotIndexed(t *testing.T) {
 	primary := NewInMemoryStorage()
 	search := setupBleveIndex(t)
 
-	storage := NewCompositeStorage(primary, search)
+	storage := NewCompositeStorage(primary, search, nil)
 
 	// Store ephemeral event (kind 20000-29999)
 	event := &Event{
@@ -230,4 +235,156 @@ func id64(prefix string) string {
 // pk64 creates a 64-char hex pubkey for testing
 func pk64(prefix string) string {
 	return id64(prefix)
+}
+
+// fakeSearchIndex is a [SearchIndex] double that lets tests trigger
+// controlled failures without standing up Bleve.
+type fakeSearchIndex struct {
+	indexErr     error
+	searchErr    error
+	searchResult []string
+}
+
+func (f *fakeSearchIndex) Index(ctx context.Context, event *Event) error {
+	return f.indexErr
+}
+
+func (f *fakeSearchIndex) Search(ctx context.Context, query string, limit int64) ([]string, error) {
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return f.searchResult, nil
+}
+
+func (f *fakeSearchIndex) Delete(ctx context.Context, eventID string) error {
+	return nil
+}
+
+// TestCompositeStorage_MetricsSearch asserts SearchTotal increments on
+// every search-backend call and SearchErrors increments (plus fallback to
+// primary fires) when the backend fails.
+func TestCompositeStorage_MetricsSearch(t *testing.T) {
+	ctx := context.Background()
+	primary := NewInMemoryStorage()
+	search := &fakeSearchIndex{}
+
+	reg := prometheus.NewRegistry()
+	metrics := NewCompositeStorageMetrics(reg)
+
+	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Metrics: metrics})
+
+	// Prime primary with one event so the fallback path returns something.
+	event := &Event{
+		ID:        id64("event1"),
+		Pubkey:    pk64("pk1"),
+		Kind:      1,
+		CreatedAt: time.Unix(1000, 0),
+		Content:   "hello",
+	}
+	if _, err := storage.Store(ctx, event); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Store triggered exactly one Index attempt (non-ephemeral, non-empty content).
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.IndexTotal))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.IndexErrors))
+
+	searchStr := "hello"
+	limit := int64(10)
+	filters := []*ReqFilter{{Search: &searchStr, Limit: &limit}}
+
+	// Case 1: search succeeds.
+	search.searchResult = []string{event.ID}
+	search.searchErr = nil
+
+	evts, errFn, closeFn := storage.Query(ctx, filters)
+	for range evts {
+	}
+	if err := errFn(); err != nil {
+		t.Fatalf("Query errFn: %v", err)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("Query closeFn: %v", err)
+	}
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.SearchTotal))
+	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.SearchErrors))
+
+	// Case 2: search errors out; Query falls back to primary.
+	search.searchResult = nil
+	search.searchErr = errors.New("bleve kaboom")
+
+	evts, errFn, closeFn = storage.Query(ctx, filters)
+	var fallbackCount int
+	for range evts {
+		fallbackCount++
+	}
+	if err := errFn(); err != nil {
+		t.Fatalf("Query errFn (fallback): %v", err)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("Query closeFn (fallback): %v", err)
+	}
+	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.SearchTotal))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.SearchErrors))
+	assert.Equal(t, 1, fallbackCount,
+		"fallback should delegate to primary, which returns the stored event")
+}
+
+// TestCompositeStorage_MetricsIndex asserts IndexTotal / IndexErrors
+// increment on Store, and ephemeral events never trigger indexing.
+func TestCompositeStorage_MetricsIndex(t *testing.T) {
+	ctx := context.Background()
+	primary := NewInMemoryStorage()
+	search := &fakeSearchIndex{indexErr: errors.New("index down")}
+
+	reg := prometheus.NewRegistry()
+	metrics := NewCompositeStorageMetrics(reg)
+
+	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Metrics: metrics})
+
+	// Store: primary succeeds, index fails. Store returns success
+	// because indexing is best-effort.
+	event := &Event{
+		ID:        id64("event1"),
+		Pubkey:    pk64("pk1"),
+		Kind:      1,
+		CreatedAt: time.Unix(1000, 0),
+		Content:   "hello",
+	}
+	stored, err := storage.Store(ctx, event)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	assert.True(t, stored, "primary should have stored the event even if indexing fails")
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.IndexTotal))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.IndexErrors))
+
+	// Ephemeral events bypass indexing entirely.
+	eph := &Event{
+		ID:        id64("eph1"),
+		Pubkey:    pk64("pk2"),
+		Kind:      20001,
+		CreatedAt: time.Unix(1001, 0),
+		Content:   "ephemeral",
+	}
+	if _, err := storage.Store(ctx, eph); err != nil {
+		t.Fatalf("Store ephemeral: %v", err)
+	}
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.IndexTotal),
+		"ephemeral events must not trigger indexing")
+
+	// Events with empty content also bypass indexing.
+	empty := &Event{
+		ID:        id64("empty1"),
+		Pubkey:    pk64("pk3"),
+		Kind:      1,
+		CreatedAt: time.Unix(1002, 0),
+		Content:   "",
+	}
+	if _, err := storage.Store(ctx, empty); err != nil {
+		t.Fatalf("Store empty: %v", err)
+	}
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.IndexTotal),
+		"empty-content events must not trigger indexing")
 }

--- a/metrics.go
+++ b/metrics.go
@@ -262,6 +262,87 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 	return m
 }
 
+// CompositeStorageMetrics holds Prometheus metrics for [CompositeStorage].
+//
+// These instrument the two places where [CompositeStorage] would otherwise
+// silently swallow backend failures:
+//
+//   - Search (Query path): on [SearchIndex].Search error the Query falls
+//     back to the primary storage, so the client sees a result — just not
+//     a search-scored one. Without [SearchErrors] the backend could be
+//     fully broken and nobody would notice.
+//   - Index (Store path): [SearchIndex].Index is best-effort (the event is
+//     already in primary), so its return value is discarded. Without
+//     [IndexErrors] the search index can silently drift out of sync with
+//     the primary.
+//
+// Pairing *Total with *Errors yields an error rate on each side. The
+// underlying Bleve / SearchIndex resource state itself (doc count, index
+// size, batch statistics) lives on the caller's [bleve.Index] and should
+// be collected directly from idx.StatsMap() by the caller — see the
+// "Caller-owned *pebble.DB and bleve.Index" section in CLAUDE.md.
+type CompositeStorageMetrics struct {
+	// SearchTotal counts Query calls that hit the search backend (Search
+	// filter non-empty and a search index is configured). Paired with
+	// SearchErrors to derive a search error rate.
+	SearchTotal prometheus.Counter
+
+	// SearchErrors counts [SearchIndex].Search failures. On failure the
+	// Query falls back to the primary storage; without this counter the
+	// failure is silent.
+	SearchErrors prometheus.Counter
+
+	// IndexTotal counts [SearchIndex].Index attempts on successful Store
+	// (non-ephemeral events with non-empty content). Paired with
+	// IndexErrors to derive an indexing error rate.
+	IndexTotal prometheus.Counter
+
+	// IndexErrors counts [SearchIndex].Index failures. Indexing is
+	// best-effort (the event is already in primary storage), so failures
+	// do not propagate to the client — but a sustained non-zero rate
+	// means the search index is drifting out of sync with the primary.
+	IndexErrors prometheus.Counter
+}
+
+// NewCompositeStorageMetrics creates and registers CompositeStorage
+// metrics with the given registry.
+func NewCompositeStorageMetrics(reg prometheus.Registerer) *CompositeStorageMetrics {
+	m := &CompositeStorageMetrics{
+		SearchTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mocrelay_search_total",
+			Help: "Total number of Query calls that hit the search backend " +
+				"(Search filter non-empty and a search index configured).",
+		}),
+		SearchErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mocrelay_search_errors_total",
+			Help: "Total number of SearchIndex.Search failures. Query falls " +
+				"back to the primary storage on failure, so clients see results " +
+				"but not search-scored ones.",
+		}),
+		IndexTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mocrelay_index_total",
+			Help: "Total number of SearchIndex.Index attempts on successful Store " +
+				"(non-ephemeral events with non-empty content).",
+		}),
+		IndexErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mocrelay_index_errors_total",
+			Help: "Total number of SearchIndex.Index failures. Indexing is " +
+				"best-effort and failures do not propagate to the client, but a " +
+				"sustained non-zero rate means the search index is drifting out " +
+				"of sync with the primary.",
+		}),
+	}
+
+	reg.MustRegister(
+		m.SearchTotal,
+		m.SearchErrors,
+		m.IndexTotal,
+		m.IndexErrors,
+	)
+
+	return m
+}
+
 // MergeHandlerMetrics holds Prometheus metrics for [NewMergeHandler].
 //
 // These surface the USE-Saturation and USE-Errors axes of the merge


### PR DESCRIPTION
## Summary

- Add `CompositeStorageMetrics` (`SearchTotal` / `SearchErrors` / `IndexTotal` / `IndexErrors`) to surface the two backend failures that `CompositeStorage` would otherwise swallow silently: `SearchIndex.Search` falls back to primary on error; `SearchIndex.Index` on `Store` is fire-and-forget. Without these, operators can't tell the search backend is broken (clients still get unscored results) or that the search index is drifting out of sync with primary.
- Emit a structured Warn log via `LoggerFromContext(ctx)` at each failure site so logs and metrics share fields (`event_id` / `query`, `error`), mirroring the `logRejection` cross-indexability pattern.
- New `CompositeStorageOptions` (`*CompositeStorageMetrics`); `NewCompositeStorage(primary, search, opts)` — **breaking** signature change, acceptable under v0.x. `nil` opts = silence, matching `RelayOptions` / `StorageMetrics` etc.
- Duration deliberately **not** added: `Search` dominates `StorageMetrics.QueryDuration` already (primary `IDs → Event` fetch is O(1) per ID). Can be reintroduced if isolating Bleve vs. Pebble slowness becomes operationally necessary — noted in CLAUDE.md Known concerns #3.
- `kitchen-sink` updated to register the new metrics. `CLAUDE.md` Coverage table splits the Bleve row into RED (internal, via `CompositeStorageMetrics`) and USE (external, via caller's `idx.StatsMap()`); Constructor API list and Known concerns #3 refreshed.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (including existing `composite_storage_test.go` cases exercised through the new third arg as `nil`)
- [x] New tests: `TestCompositeStorage_MetricsSearch` (success path ↑SearchTotal, error path ↑SearchTotal+SearchErrors + fallback returns primary result), `TestCompositeStorage_MetricsIndex` (Store error-indexing path ↑IndexTotal+IndexErrors but Store still succeeds; ephemeral and empty-content events bypass indexing entirely)
- [x] Warn log output confirmed in verbose test run

🌸 Generated with [Claude Code](https://claude.com/claude-code)