### PR TITLE
refactor: AuthMetrics via ctx (RelayOptions.AuthMetrics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,29 +247,35 @@ The `middleware` axis lets operators scope further:
 Metrics are optional, matching the philosophy of `Relay.Logger`. Two
 injection shapes coexist:
 
-- **Per-owner options** (`RelayMetrics`, `RouterMetrics`, `AuthMetrics`,
+- **Per-owner options** (`RelayMetrics`, `RouterMetrics`,
   `StorageMetrics`, `MergeHandlerMetrics`, `CompositeStorageMetrics`):
   passed through the owning
   type's `*Options` struct. `nil` means "don't measure, don't allocate."
   Call sites guard with a nil check so the instrument-free build path
-  has zero runtime cost and no Prometheus dependency surface.
-- **Context-injected** (`RejectionMetrics`): threaded through the
-  request context, symmetric with `Logger`. `Relay` installs it once
-  per connection; middleware never holds a reference, never needs a
-  nil check — `logRejection` reads it via `RejectionMetricsFromContext`
-  and no-ops on nil. This keeps the per-middleware API surface minimal
-  (no per-middleware metrics field just for rejections) and keeps
-  rejection reporting lazily DRY: a new middleware that calls
-  `logRejection` is automatically observable on day one.
+  has zero runtime cost and no Prometheus dependency surface. These
+  are all measured by the owning type itself (Relay measures Relay,
+  Storage measures Storage, …), so there is nothing request-scoped to
+  propagate — Options is the right place.
+- **Context-injected** (`RejectionMetrics`, `AuthMetrics`): threaded
+  through the request context, symmetric with `Logger`. `Relay`
+  installs them once per connection from `RelayOptions.RejectionMetrics`
+  / `RelayOptions.AuthMetrics`; middleware never holds a reference,
+  never needs a nil check — the middleware reads them via
+  `RejectionMetricsFromContext` / `AuthMetricsFromContext` and no-ops
+  on nil. The rule for picking this shape over Options is "the metric
+  is consumed by a unit that composes *into* a Relay
+  (handler / middleware), rather than by the unit itself." Logger
+  follows the same rule, which is why it shares the ctx path.
 
 Just as `Logger == nil` falls back to `slog.Default()`, both
-`Metrics == nil` and a ctx without `RejectionMetrics` fall back to
-silence.
+`Metrics == nil` and a ctx without `RejectionMetrics` / `AuthMetrics`
+fall back to silence.
 
-A natural future step is to migrate the remaining `*Metrics` types onto
-the context-injected shape so that the whole metrics surface matches
-the `Logger` pattern, but that's deferred until a second metric
-(beyond rejections) is shown to benefit from ctx scope.
+`MergeHandlerMetrics` is the next candidate to consider for the
+context-injected set under the same rule (consumed by a handler that
+composes into Relay rather than by Relay itself). It is left on
+Options for now; a follow-up PR can evaluate the move once a concrete
+need arises.
 
 #### Coverage by layer (drives follow-up PRs)
 
@@ -437,8 +443,14 @@ Rules:
   does not re-check for zero values. Writing `if x == 0 { x = default }`
   at call sites is a smell — it means the constructor did not finish
   its job.
-- **Metrics are a field of Options**, not a separate positional arg or
-  a post-construction field. Uniform with every other optional setting.
+- **Metrics are a field of some `*Options` struct**, not a separate
+  positional arg or a post-construction field. Which Options depends on
+  the consumer: types that measure themselves (e.g. `RouterMetrics` on
+  `RouterOptions`) keep Metrics on their own Options; types that are
+  composed *into* `Relay` and measured while serving a request
+  (`AuthMetrics`, `RejectionMetrics`) put Metrics on `RelayOptions` and
+  let `Relay` install them into the request context. See the "Nil-safe
+  injection" section in the Metrics policy above for the full rule.
 
 This pattern is used by `NewRelay`, `NewRouter`, `NewAuthMiddlewareBase`,
 `NewPebbleStorage`, `NewBleveIndex`, and `NewCompositeStorage`. New

--- a/cmd/examples/kitchen-sink/main.go
+++ b/cmd/examples/kitchen-sink/main.go
@@ -128,9 +128,9 @@ func main() {
 
 	handler = mocrelay.NewSimpleMiddleware(
 		// Auth (NIP-42): challenge/response authentication.
-		mocrelay.NewAuthMiddlewareBase("wss://relay.example.com/", &mocrelay.AuthMiddlewareOptions{
-			Metrics: authMetrics,
-		}),
+		// AuthMetrics is injected via RelayOptions.AuthMetrics below,
+		// picked up by the middleware via AuthMetricsFromContext.
+		mocrelay.NewAuthMiddlewareBase("wss://relay.example.com/", nil),
 
 		// Protected events (NIP-70): prevent republishing "-" tagged events.
 		mocrelay.NewProtectedEventsMiddlewareBase(),
@@ -158,8 +158,9 @@ func main() {
 	// --- Relay ---
 
 	relay := mocrelay.NewRelay(handler, &mocrelay.RelayOptions{
-		Logger:  logger,
-		Metrics: relayMetrics,
+		Logger:      logger,
+		Metrics:     relayMetrics,
+		AuthMetrics: authMetrics,
 		Info: &mocrelay.RelayInfo{
 			Name:          "mocrelay-kitchen-sink",
 			Description:   "A full-featured Nostr relay example",

--- a/metrics.go
+++ b/metrics.go
@@ -122,6 +122,11 @@ func NewRouterMetrics(reg prometheus.Registerer) *RouterMetrics {
 
 // AuthMetrics holds Prometheus metrics for AuthMiddleware.
 //
+// AuthMetrics is injected into the request context by [Relay] (via
+// [RelayOptions.AuthMetrics]); the auth middleware reads it via
+// [AuthMetricsFromContext] and no-ops on nil. Middleware code never holds a
+// reference directly, mirroring the [RejectionMetrics] / Logger pattern.
+//
 // Rejection metrics are not part of this struct. They are unified across all
 // middleware under [RejectionMetrics] and are wired automatically via
 // [logRejection] — Auth contributes to the shared counter with label
@@ -150,6 +155,25 @@ func NewAuthMetrics(reg prometheus.Registerer) *AuthMetrics {
 	)
 
 	return m
+}
+
+type authMetricsKey struct{}
+
+// ContextWithAuthMetrics returns a new context carrying the given auth
+// metrics. [Relay] installs this at connection start so the auth middleware
+// downstream can record attempts and authenticated connections via
+// [AuthMetricsFromContext] without holding a direct reference.
+func ContextWithAuthMetrics(ctx context.Context, m *AuthMetrics) context.Context {
+	return context.WithValue(ctx, authMetricsKey{}, m)
+}
+
+// AuthMetricsFromContext returns the auth metrics from the context, or nil
+// if none was set. Callers must be nil-safe.
+func AuthMetricsFromContext(ctx context.Context) *AuthMetrics {
+	if m, ok := ctx.Value(authMetricsKey{}).(*AuthMetrics); ok {
+		return m
+	}
+	return nil
 }
 
 // RejectionMetrics holds the unified rejection counter shared across every

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -12,14 +12,15 @@ import (
 // AuthMiddlewareOptions configures the middleware returned by
 // [NewAuthMiddlewareBase]. All fields are optional; the zero value gives
 // sensible defaults.
+//
+// Metrics are not part of this struct. [AuthMetrics] is injected via the
+// request context by [Relay] (see [RelayOptions.AuthMetrics]) and read by
+// the auth middleware via [AuthMetricsFromContext], mirroring the
+// [RejectionMetrics] / Logger pattern.
 type AuthMiddlewareOptions struct {
 	// CreatedAtTolerance is the maximum age of auth events.
 	// Default: 10 minutes (as recommended by NIP-42)
 	CreatedAtTolerance time.Duration
-
-	// Metrics is the Prometheus metrics collector for authentication.
-	// If nil, no metrics are collected.
-	Metrics *AuthMetrics
 }
 
 // NewAuthMiddlewareBase creates a middleware base that requires NIP-42
@@ -40,14 +41,12 @@ func NewAuthMiddlewareBase(relayURL string, opts *AuthMiddlewareOptions) SimpleM
 	return &authMiddleware{
 		relayURL:           relayURL,
 		createdAtTolerance: tolerance,
-		metrics:            opts.Metrics,
 	}
 }
 
 type authMiddleware struct {
 	relayURL           string
 	createdAtTolerance time.Duration
-	metrics            *AuthMetrics
 }
 
 // authState holds per-connection authentication state.
@@ -78,14 +77,14 @@ func (m *authMiddleware) OnStart(ctx context.Context) (context.Context, *ServerM
 }
 
 func (m *authMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
-	if m.metrics != nil {
+	if metrics := AuthMetricsFromContext(ctx); metrics != nil {
 		state := ctx.Value(authCtxKey{}).(*authState)
 		state.mu.RLock()
 		authenticated := state.authenticated
 		state.mu.RUnlock()
 
 		if authenticated {
-			m.metrics.AuthenticatedConnectionsCurrent.Dec()
+			metrics.AuthenticatedConnectionsCurrent.Dec()
 		}
 	}
 
@@ -142,6 +141,8 @@ func (m *authMiddleware) HandleServerMsg(
 }
 
 func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	metrics := AuthMetricsFromContext(ctx)
+
 	if msg.Event == nil {
 		logRejection(ctx, "auth", "missing_auth_event")
 		return nil, NewServerOKMsg("", false, "invalid: missing auth event"), nil
@@ -151,8 +152,8 @@ func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *
 
 	// Validate kind
 	if event.Kind != 22242 {
-		if m.metrics != nil {
-			m.metrics.AuthTotal.WithLabelValues("invalid_kind").Inc()
+		if metrics != nil {
+			metrics.AuthTotal.WithLabelValues("invalid_kind").Inc()
 		}
 		logRejection(ctx, "auth", "invalid_kind",
 			"event_id", event.ID,
@@ -164,8 +165,8 @@ func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *
 	// Validate created_at (within tolerance)
 	now := time.Now()
 	if event.CreatedAt.Before(now.Add(-m.createdAtTolerance)) || event.CreatedAt.After(now.Add(m.createdAtTolerance)) {
-		if m.metrics != nil {
-			m.metrics.AuthTotal.WithLabelValues("expired").Inc()
+		if metrics != nil {
+			metrics.AuthTotal.WithLabelValues("expired").Inc()
 		}
 		logRejection(ctx, "auth", "expired",
 			"event_id", event.ID,
@@ -181,8 +182,8 @@ func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *
 	state.mu.RUnlock()
 
 	if challengeTag != expectedChallenge {
-		if m.metrics != nil {
-			m.metrics.AuthTotal.WithLabelValues("challenge_mismatch").Inc()
+		if metrics != nil {
+			metrics.AuthTotal.WithLabelValues("challenge_mismatch").Inc()
 		}
 		logRejection(ctx, "auth", "challenge_mismatch",
 			"event_id", event.ID,
@@ -196,8 +197,8 @@ func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *
 		// Simple check: just verify it's not empty for now
 		// More sophisticated URL normalization could be added
 		if relayTag == "" {
-			if m.metrics != nil {
-				m.metrics.AuthTotal.WithLabelValues("invalid_relay").Inc()
+			if metrics != nil {
+				metrics.AuthTotal.WithLabelValues("invalid_relay").Inc()
 			}
 			logRejection(ctx, "auth", "missing_relay_tag",
 				"event_id", event.ID,
@@ -207,15 +208,15 @@ func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *
 	}
 
 	// Authentication successful
-	if m.metrics != nil {
-		m.metrics.AuthTotal.WithLabelValues("success").Inc()
+	if metrics != nil {
+		metrics.AuthTotal.WithLabelValues("success").Inc()
 	}
 
 	state.mu.Lock()
 	state.authedPubkeys[event.Pubkey] = struct{}{}
-	if m.metrics != nil && !state.authenticated {
+	if metrics != nil && !state.authenticated {
 		state.authenticated = true
-		m.metrics.AuthenticatedConnectionsCurrent.Inc()
+		metrics.AuthenticatedConnectionsCurrent.Inc()
 	}
 	state.mu.Unlock()
 

--- a/relay.go
+++ b/relay.go
@@ -27,6 +27,7 @@ type Relay struct {
 	info             *RelayInfo
 	metrics          *RelayMetrics
 	rejectionMetrics *RejectionMetrics
+	authMetrics      *AuthMetrics
 	connIDFunc       func() string
 
 	mu      sync.Mutex
@@ -74,6 +75,14 @@ type RelayOptions struct {
 	// only logged — no counter is incremented.
 	RejectionMetrics *RejectionMetrics
 
+	// AuthMetrics is the Prometheus metrics collector for the auth
+	// middleware (NIP-42). If set, the relay installs it into the request
+	// context so that NewAuthMiddlewareBase downstream records attempts
+	// and authenticated connections via AuthMetricsFromContext. If nil,
+	// auth events are not measured (rejections are still counted via
+	// RejectionMetrics with middleware="auth" where applicable).
+	AuthMetrics *AuthMetrics
+
 	// ConnIDFunc generates a unique connection ID string.
 	// If nil, a default monotonic counter ("1", "2", ...) is used.
 	ConnIDFunc func() string
@@ -115,6 +124,7 @@ func NewRelay(handler Handler, opts *RelayOptions) *Relay {
 		info:             opts.Info,
 		metrics:          opts.Metrics,
 		rejectionMetrics: opts.RejectionMetrics,
+		authMetrics:      opts.AuthMetrics,
 		connIDFunc:       opts.ConnIDFunc,
 	}
 }
@@ -229,6 +239,9 @@ func (r *Relay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx = ContextWithLogger(ctx, logger)
 	if r.rejectionMetrics != nil {
 		ctx = ContextWithRejectionMetrics(ctx, r.rejectionMetrics)
+	}
+	if r.authMetrics != nil {
+		ctx = ContextWithAuthMetrics(ctx, r.authMetrics)
 	}
 
 	// Metrics: connection tracking


### PR DESCRIPTION
## Summary

- Move `AuthMetrics` onto the same context-injection path as `RejectionMetrics` / `Logger`.
- Establish the rule: metrics consumed by a unit that composes *into* `Relay` (handler / middleware) flow through the request context; metrics that measure the owning type itself stay on that type's own Options.
- **BREAKING**: `AuthMiddlewareOptions.Metrics` is removed. Callers move the value to `RelayOptions.AuthMetrics`.

## Changes

- `metrics.go`: add `ContextWithAuthMetrics` / `AuthMetricsFromContext`; update `AuthMetrics` godoc.
- `middleware_auth.go`: drop `AuthMiddlewareOptions.Metrics` and the `authMiddleware.metrics` field; each auth path now reads `AuthMetricsFromContext(ctx)` on demand and no-ops on nil.
- `relay.go`: add `RelayOptions.AuthMetrics` and install it into the request context at connection start, alongside `RejectionMetrics`.
- `cmd/examples/kitchen-sink`: move the `AuthMetrics` wiring from middleware options to `RelayOptions`.
- `CLAUDE.md`: rewrite the "Nil-safe injection" section around the consumer-measures-itself-vs-composed-into-Relay rule, clarify the same rule on the Constructor API policy, and note `MergeHandlerMetrics` as a follow-up candidate (same rule would apply).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all green, 0.24s)
- [x] kitchen-sink example builds with the new wiring

🌸 Generated with [Claude Code](https://claude.com/claude-code)