### PR TITLE
feat: log slow REQ / COUNT with scan vs send-wait breakdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,38 @@ middleware policy (`MaxEventTags` dropping oversized events, `AuthRequired`
 rejecting unauthenticated REQs, …). Enable Debug when investigating why a
 specific client is being dropped; rely on metrics day-to-day.
 
+**Slow REQ / COUNT logging** (`StorageHandlerOptions.SlowQueryThreshold`):
+
+`StorageHandler` emits a **Warn** log (`"storage: slow REQ"` /
+`"storage: slow COUNT"`) when a subscription's total duration exceeds a
+configurable threshold (default 1s; zero uses the default, negative
+disables). The log carries:
+
+- `subscription_id`, `filters`
+- `events_sent` (REQ) or `count` (COUNT)
+- `total_ms` — wall time from `Query` call through EOSE / COUNT yield
+- For REQ: `scan_ms` and `send_wait_ms` — time spent outside vs inside
+  `yield`, summing to `total_ms`
+- `completed` (REQ) — false if the REQ was abandoned before EOSE
+
+Why the scan / send-wait split exists: `iter.Seq` is pull-driven, so a
+blocked `yield` also pauses the storage iterator — the two time windows
+are not independent. But the split is still operationally useful because
+*which side owns the stall* determines the fix:
+
+- `send_wait_ms >> scan_ms` → the client is failing to drain its send
+  path (slow consumer, dead TCP peer, network congestion). Look at WS
+  write timeouts and router drop metrics.
+- `scan_ms >> send_wait_ms` → the filter / index / data volume is the
+  bottleneck. Look at `db.Metrics()` (L0 files, compaction debt) and
+  the filter shape.
+- Both large → genuinely heavy query *and* slow consumer; typical when a
+  client subscribes with a broad filter and can't keep up.
+
+This is the complement to the `QueryDuration` histogram: the histogram
+answers "how often are REQs slow?", the Warn log answers "which REQs,
+with what shape, and which side owns the latency?"
+
 ### Metrics
 
 **Observability stance**: metrics and logs are complementary. Logs (from
@@ -453,7 +485,8 @@ Rules:
   injection" section in the Metrics policy above for the full rule.
 
 This pattern is used by `NewRelay`, `NewRouter`, `NewAuthMiddlewareBase`,
-`NewPebbleStorage`, `NewBleveIndex`, and `NewCompositeStorage`. New
+`NewPebbleStorage`, `NewBleveIndex`, `NewCompositeStorage`, and
+`NewStorageHandler`. New
 Handlers / Middlewares / Storages added to mocrelay should follow the
 same shape so third-party code composing with mocrelay has a predictable
 surface.
@@ -692,7 +725,7 @@ child wraps an external relay.
 ```go
 handler := NewMergeHandler(
     []Handler{
-        NewStorageHandler(storage),  // Fetch past events
+        NewStorageHandler(storage, nil),  // Fetch past events
         NewRouterHandler(router),    // Real-time delivery
     },
     nil, // *MergeHandlerOptions; nil = defaults
@@ -877,7 +910,7 @@ if err != nil { ... }
 defer db.Close()  // ← caller closes the DB
 
 storage := NewPebbleStorage(db, nil) // no error, no Close()
-handler := NewStorageHandler(storage)
+handler := NewStorageHandler(storage, nil)
 relay := NewRelay(handler, nil)
 ```
 

--- a/cmd/examples/kitchen-sink/main.go
+++ b/cmd/examples/kitchen-sink/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	handler := mocrelay.NewMergeHandler(
 		[]mocrelay.Handler{
-			mocrelay.NewStorageHandler(storage),
+			mocrelay.NewStorageHandler(storage, nil),
 			mocrelay.NewRouterHandler(router),
 		},
 		nil, // default options

--- a/cmd/examples/minimal/main.go
+++ b/cmd/examples/minimal/main.go
@@ -44,7 +44,7 @@ func main() {
 	// Handler: merge storage (past events) and router (real-time).
 	handler := mocrelay.NewMergeHandler(
 		[]mocrelay.Handler{
-			mocrelay.NewStorageHandler(storage),
+			mocrelay.NewStorageHandler(storage, nil),
 			mocrelay.NewRouterHandler(router),
 		},
 		nil, // default options

--- a/doc.go
+++ b/doc.go
@@ -73,7 +73,7 @@
 //	router := NewRouter(nil)
 //	handler := NewMergeHandler(
 //	    []Handler{
-//	        NewStorageHandler(storage),
+//	        NewStorageHandler(storage, nil),
 //	        NewRouterHandler(router),
 //	    },
 //	    nil,

--- a/merge_handler_test.go
+++ b/merge_handler_test.go
@@ -194,8 +194,8 @@ func TestMergeHandler_Req_EventsWithDedupe(t *testing.T) {
 		storage2.Store(ctx, makeEvent("bbb", "pubkey01", 1, 100)) // duplicate
 		storage2.Store(ctx, makeEvent("ccc", "pubkey01", 1, 100))
 
-		handler1 := NewStorageHandler(storage1)
-		handler2 := NewStorageHandler(storage2)
+		handler1 := NewStorageHandler(storage1, nil)
+		handler2 := NewStorageHandler(storage2, nil)
 
 		mergeHandler := NewMergeHandler([]Handler{handler1, handler2}, nil)
 
@@ -263,8 +263,8 @@ func TestMergeHandler_Req_SortDrop(t *testing.T) {
 		storage2.Store(ctx, makeEvent("event-b", "pubkey01", 1, 400)) // even newer! should be dropped
 		storage2.Store(ctx, makeEvent("event-c", "pubkey01", 1, 100)) // oldest, OK
 
-		handler1 := NewStorageHandler(storage1)
-		handler2 := NewStorageHandler(storage2)
+		handler1 := NewStorageHandler(storage1, nil)
+		handler2 := NewStorageHandler(storage2, nil)
 
 		mergeHandler := NewMergeHandler([]Handler{handler1, handler2}, nil)
 
@@ -336,7 +336,7 @@ func TestMergeHandler_Req_SortTiebreakASC(t *testing.T) {
 		storage.Store(ctx, makeEvent("bbb", "pubkey01", 1, 100))
 		storage.Store(ctx, makeEvent("ccc", "pubkey01", 1, 100))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 		mergeHandler := NewMergeHandler([]Handler{handler}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
@@ -391,7 +391,7 @@ func TestMergeHandler_Req_Limit(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-4", "pubkey01", 1, 200))
 		storage.Store(ctx, makeEvent("event-5", "pubkey01", 1, 100))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 		mergeHandler := NewMergeHandler([]Handler{handler}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
@@ -456,7 +456,7 @@ func TestMergeHandler_Req_EventAfterHandlerEOSE(t *testing.T) {
 			event: makeEvent("event-2", "pubkey01", 1, 200),
 		}
 
-		mergeHandler := NewMergeHandler([]Handler{NewStorageHandler(storage), lateEventHandler}, nil)
+		mergeHandler := NewMergeHandler([]Handler{NewStorageHandler(storage, nil), lateEventHandler}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -529,8 +529,8 @@ func TestMergeHandler_Count(t *testing.T) {
 		storage2.Store(ctx, makeEvent("event-4", "pubkey01", 1, 400))
 		storage2.Store(ctx, makeEvent("event-5", "pubkey01", 1, 500))
 
-		handler1 := NewStorageHandler(storage1) // 3 events
-		handler2 := NewStorageHandler(storage2) // 2 events
+		handler1 := NewStorageHandler(storage1, nil) // 3 events
+		handler2 := NewStorageHandler(storage2, nil) // 2 events
 		mergeHandler := NewMergeHandler([]Handler{handler1, handler2}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
@@ -614,8 +614,8 @@ func TestMergeHandler_Req_Limit_MultipleHandlers(t *testing.T) {
 		storage2.Store(ctx, makeEvent("event-4", "pubkey01", 1, 300))
 		storage2.Store(ctx, makeEvent("event-6", "pubkey01", 1, 100))
 
-		handler1 := NewStorageHandler(storage1)
-		handler2 := NewStorageHandler(storage2)
+		handler1 := NewStorageHandler(storage1, nil)
+		handler2 := NewStorageHandler(storage2, nil)
 		mergeHandler := NewMergeHandler([]Handler{handler1, handler2}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
@@ -691,7 +691,7 @@ func TestMergeHandler_Req_Limit_RealTimeEventsAfterEOSE(t *testing.T) {
 			event:     realTimeEvent,
 		}
 
-		mergeHandler := NewMergeHandler([]Handler{NewStorageHandler(storage), rtHandler}, nil)
+		mergeHandler := NewMergeHandler([]Handler{NewStorageHandler(storage, nil), rtHandler}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -1365,7 +1365,7 @@ func TestMergeHandler_Req_SubIDReuseWithoutClose(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-2", "pubkey01", 1, 400))
 		storage.Store(ctx, makeEvent("event-3", "pubkey01", 1, 300))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 		mergeHandler := NewMergeHandler([]Handler{handler}, nil)
 
 		ctx, cancel := context.WithCancel(ctx)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -255,7 +255,7 @@ func TestMetrics_MergeHandler_EventDrops_Duplicate(t *testing.T) {
 		storage2.Store(ctx, makeEvent("dup", "pubkey01", 1, 100))
 
 		mh := NewMergeHandler(
-			[]Handler{NewStorageHandler(storage1), NewStorageHandler(storage2)},
+			[]Handler{NewStorageHandler(storage1, nil), NewStorageHandler(storage2, nil)},
 			&MergeHandlerOptions{Metrics: metrics},
 		)
 

--- a/storage_differential_test.go
+++ b/storage_differential_test.go
@@ -324,8 +324,8 @@ func testStorageHandlerDifferentialWithSeed(t *testing.T, seed uint64) {
 	pebbleStorage := NewPebbleStorage(openTestPebbleDB(t), nil)
 
 	// Create handlers
-	handlerInMem := NewStorageHandler(inMemory)
-	handlerPebble := NewStorageHandler(pebbleStorage)
+	handlerInMem := NewStorageHandler(inMemory, nil)
+	handlerPebble := NewStorageHandler(pebbleStorage, nil)
 
 	// Create channels for both handlers
 	sendInMem := make(chan *ServerMsg, 100)

--- a/storage_handler.go
+++ b/storage_handler.go
@@ -3,10 +3,36 @@ package mocrelay
 import (
 	"context"
 	"iter"
+	"time"
 )
 
+// DefaultStorageHandlerSlowQueryThreshold is the default threshold for
+// logging a slow REQ / COUNT subscription when
+// [StorageHandlerOptions.SlowQueryThreshold] is zero.
+const DefaultStorageHandlerSlowQueryThreshold = 1 * time.Second
+
+// StorageHandlerOptions configures the storage handler returned by
+// [NewStorageHandler].
+//
+// All fields are optional. A nil *StorageHandlerOptions is equivalent to a
+// zero-valued StorageHandlerOptions and means "use defaults for everything".
+type StorageHandlerOptions struct {
+	// SlowQueryThreshold sets the total-duration threshold above which a REQ
+	// or COUNT subscription is logged at Warn via [LoggerFromContext]. The
+	// emitted log carries a breakdown (scan vs send-wait time for REQ) so
+	// operators can distinguish a genuinely heavy query from a client that
+	// is failing to drain its send buffer — the two are entangled because
+	// iter.Seq is pull-driven and pauses the storage iterator while yield
+	// is blocked, so having both numbers side-by-side is the most reliable
+	// signal of which side owns the stall.
+	//
+	// A zero value selects [DefaultStorageHandlerSlowQueryThreshold] (1s).
+	// A negative value disables slow-query logging entirely.
+	SlowQueryThreshold time.Duration
+}
+
 // NewStorageHandler returns a [Handler] that serves EVENT and REQ messages
-// against storage.
+// against storage. Pass nil for opts to use defaults.
 //
 // Behavior:
 //   - EVENT: Store the event, return OK
@@ -17,12 +43,27 @@ import (
 //
 // Once EOSE is sent for a REQ, the handler's job is done for that
 // subscription.
-func NewStorageHandler(storage Storage) Handler {
-	return NewSimpleHandler(&storageHandler{storage: storage})
+func NewStorageHandler(storage Storage, opts *StorageHandlerOptions) Handler {
+	threshold := DefaultStorageHandlerSlowQueryThreshold
+	if opts != nil {
+		switch {
+		case opts.SlowQueryThreshold < 0:
+			threshold = 0 // disabled
+		case opts.SlowQueryThreshold > 0:
+			threshold = opts.SlowQueryThreshold
+		}
+	}
+	return NewSimpleHandler(&storageHandler{
+		storage:            storage,
+		slowQueryThreshold: threshold,
+	})
 }
 
 type storageHandler struct {
 	storage Storage
+	// slowQueryThreshold is the effective threshold for slow-query logging.
+	// Zero means disabled.
+	slowQueryThreshold time.Duration
 }
 
 func (h *storageHandler) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
@@ -78,25 +119,51 @@ func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Se
 			return
 		}
 
+		// start is taken before Query so the iterator-initialization cost
+		// (index seek, snapshot creation, etc.) counts toward total.
+		start := time.Now()
+
 		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
 		defer closeFn()
 
-		// Send all events using for-range over iterator
+		// Measure time spent inside yield (send wait) vs outside yield
+		// (scan). iter.Seq is pull-driven so yield blocking also pauses
+		// the storage iterator — the two are entangled. But the split
+		// is still operationally meaningful: a large sendWait relative
+		// to scan points at a stalled client; the reverse points at
+		// filter / index / data-volume costs.
+		var sendWait time.Duration
+		eventsSent := 0
+
+		// yieldTracked wraps yield so every emission contributes to
+		// sendWait, including the trailing EOSE — which matters when
+		// the stall is on the client side (EOSE never arrives either).
+		yieldTracked := func(m *ServerMsg) bool {
+			s := time.Now()
+			ok := yield(m)
+			sendWait += time.Since(s)
+			return ok
+		}
+
 		for event := range events {
-			if !yield(NewServerEventMsg(msg.SubscriptionID, event)) {
+			if !yieldTracked(NewServerEventMsg(msg.SubscriptionID, event)) {
+				h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
 				return
 			}
+			eventsSent++
 		}
 
 		// Check for errors after iteration
 		if err := errFn(); err != nil {
 			LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err, "subscription_id", msg.SubscriptionID)
-			yield(NewServerEOSEMsg(msg.SubscriptionID))
+			yieldTracked(NewServerEOSEMsg(msg.SubscriptionID))
+			h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, true)
 			return
 		}
 
 		// Send EOSE to signal end of stored events
-		yield(NewServerEOSEMsg(msg.SubscriptionID))
+		yieldTracked(NewServerEOSEMsg(msg.SubscriptionID))
+		h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, true)
 	}, nil
 }
 
@@ -106,10 +173,15 @@ func (h *storageHandler) handleCount(ctx context.Context, msg *ClientMsg) (iter.
 			return
 		}
 
+		// COUNT emits a single terminal message, so there is no
+		// meaningful send-wait component during iteration — total
+		// duration is dominated by scan. start is taken before Query so
+		// iterator-initialization cost counts toward total.
+		start := time.Now()
+
 		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
 		defer closeFn()
 
-		// Count events by iterating
 		count := uint64(0)
 		for range events {
 			count++
@@ -118,9 +190,63 @@ func (h *storageHandler) handleCount(ctx context.Context, msg *ClientMsg) (iter.
 		if err := errFn(); err != nil {
 			LoggerFromContext(ctx).WarnContext(ctx, "count query error", "error", err, "subscription_id", msg.SubscriptionID)
 			yield(NewServerCountMsg(msg.SubscriptionID, 0, nil))
+			h.maybeLogSlowCount(ctx, msg, start, count)
 			return
 		}
 
 		yield(NewServerCountMsg(msg.SubscriptionID, count, nil))
+		h.maybeLogSlowCount(ctx, msg, start, count)
 	}, nil
+}
+
+// maybeLogSlowReq emits a Warn log when the REQ total duration exceeds the
+// configured slowQueryThreshold. A zero threshold disables logging.
+func (h *storageHandler) maybeLogSlowReq(
+	ctx context.Context,
+	msg *ClientMsg,
+	start time.Time,
+	sendWait time.Duration,
+	eventsSent int,
+	completed bool,
+) {
+	if h.slowQueryThreshold <= 0 {
+		return
+	}
+	total := time.Since(start)
+	if total < h.slowQueryThreshold {
+		return
+	}
+	scan := max(total-sendWait, 0)
+	LoggerFromContext(ctx).WarnContext(ctx, "storage: slow REQ",
+		"subscription_id", msg.SubscriptionID,
+		"filters", msg.Filters,
+		"events_sent", eventsSent,
+		"total_ms", total.Milliseconds(),
+		"scan_ms", scan.Milliseconds(),
+		"send_wait_ms", sendWait.Milliseconds(),
+		"completed", completed,
+	)
+}
+
+// maybeLogSlowCount emits a Warn log when the COUNT total duration exceeds
+// the configured slowQueryThreshold. A zero threshold disables logging.
+func (h *storageHandler) maybeLogSlowCount(
+	ctx context.Context,
+	msg *ClientMsg,
+	start time.Time,
+	count uint64,
+) {
+	if h.slowQueryThreshold <= 0 {
+		return
+	}
+	total := time.Since(start)
+	if total < h.slowQueryThreshold {
+		return
+	}
+	LoggerFromContext(ctx).WarnContext(ctx, "storage: slow COUNT",
+		"subscription_id", msg.SubscriptionID,
+		"filters", msg.Filters,
+		"count", count,
+		"total_ms", total.Milliseconds(),
+	)
 }

--- a/storage_handler_test.go
+++ b/storage_handler_test.go
@@ -1,9 +1,14 @@
 package mocrelay
 
 import (
+	"bytes"
 	"context"
+	"iter"
+	"log/slog"
+	"strings"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +17,7 @@ import (
 func TestStorageHandler_Event_Store(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		storage := NewInMemoryStorage()
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -49,7 +54,7 @@ func TestStorageHandler_Event_Store(t *testing.T) {
 func TestStorageHandler_Event_Duplicate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		storage := NewInMemoryStorage()
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -86,7 +91,7 @@ func TestStorageHandler_Event_Duplicate(t *testing.T) {
 func TestStorageHandler_Req_Empty(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		storage := NewInMemoryStorage()
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -126,7 +131,7 @@ func TestStorageHandler_Req_WithEvents(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-2", "pubkey01", 1, 200))
 		storage.Store(ctx, makeEvent("event-3", "pubkey01", 1, 300))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -180,7 +185,7 @@ func TestStorageHandler_Req_WithLimit(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-2", "pubkey01", 1, 200))
 		storage.Store(ctx, makeEvent("event-3", "pubkey01", 1, 300))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -225,7 +230,7 @@ func TestStorageHandler_Req_WithLimit(t *testing.T) {
 func TestStorageHandler_Close_NoOp(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		storage := NewInMemoryStorage()
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -263,7 +268,7 @@ func TestStorageHandler_Count(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-2", "pubkey01", 1, 200))
 		storage.Store(ctx, makeEvent("event-3", "pubkey01", 1, 300))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -304,7 +309,7 @@ func TestStorageHandler_Count_WithFilter(t *testing.T) {
 		storage.Store(ctx, makeEvent("event-2", "pubkey01", 2, 200))
 		storage.Store(ctx, makeEvent("event-3", "pubkey01", 1, 300))
 
-		handler := NewStorageHandler(storage)
+		handler := NewStorageHandler(storage, nil)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -330,6 +335,172 @@ func TestStorageHandler_Count_WithFilter(t *testing.T) {
 			assert.Equal(t, uint64(2), msg.Count)
 		default:
 			t.Fatal("expected COUNT message")
+		}
+	})
+}
+
+// delayedQueryStorage wraps a Storage and sleeps for delay before returning
+// from Query — useful to force the slow-query logging path under synctest
+// (time.Sleep advances synctest's virtual clock).
+type delayedQueryStorage struct {
+	inner Storage
+	delay time.Duration
+}
+
+func (s *delayedQueryStorage) Store(ctx context.Context, event *Event) (bool, error) {
+	return s.inner.Store(ctx, event)
+}
+
+func (s *delayedQueryStorage) Query(
+	ctx context.Context,
+	filters []*ReqFilter,
+) (iter.Seq[*Event], func() error, func() error) {
+	time.Sleep(s.delay)
+	return s.inner.Query(ctx, filters)
+}
+
+// runSlowQueryServeNostr is a shared fixture for the slow-query tests: it
+// wires up a handler, an in-memory storage wrapped in a delay shim, a slog
+// text handler into buf, and drives a single ClientMsg through ServeNostr.
+// synctest time is advanced by test-goroutine time.Sleep (past advance) so
+// the delayed Query path actually resolves before assertions run.
+func runSlowQueryServeNostr(
+	t *testing.T,
+	msg *ClientMsg,
+	opts *StorageHandlerOptions,
+	delay time.Duration,
+	advance time.Duration,
+) string {
+	t.Helper()
+	ctx := context.Background()
+	base := NewInMemoryStorage()
+	base.Store(ctx, makeEvent("event-1", "pubkey01", 1, 100))
+
+	storage := &delayedQueryStorage{inner: base, delay: delay}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	handler := NewStorageHandler(storage, opts)
+
+	ctx = ContextWithLogger(ctx, logger)
+	ctx, cancel := context.WithCancel(ctx)
+
+	send := make(chan *ServerMsg, 10)
+	recv := make(chan *ClientMsg, 10)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- handler.ServeNostr(ctx, send, recv) }()
+
+	recv <- msg
+
+	// time.Sleep (not just synctest.Wait) is required to advance the fake
+	// clock — see merge_handler_test.go for the same pattern.
+	time.Sleep(advance)
+	synctest.Wait()
+
+	cancel()
+	synctest.Wait()
+	<-errCh
+	return buf.String()
+}
+
+func TestStorageHandler_SlowQuery_ReqLogsOnThresholdExceeded(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		out := runSlowQueryServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{SlowQueryThreshold: 100 * time.Millisecond},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		for _, want := range []string{
+			`level=WARN`,
+			`msg="storage: slow REQ"`,
+			`subscription_id=sub1`,
+			`events_sent=1`,
+			`completed=true`,
+			`total_ms=`,
+			`scan_ms=`,
+			`send_wait_ms=`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q\nfull output: %s", want, out)
+			}
+		}
+	})
+}
+
+func TestStorageHandler_SlowQuery_ReqNoLogBelowThreshold(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Delay is below the default 1s threshold: must not log.
+		out := runSlowQueryServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			nil, // default 1s
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		if strings.Contains(out, "slow REQ") {
+			t.Errorf("slow REQ should not be logged below default 1s threshold:\n%s", out)
+		}
+	})
+}
+
+func TestStorageHandler_SlowQuery_Disabled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Large delay that would trip any positive threshold, but a
+		// negative threshold disables slow-query logging entirely.
+		out := runSlowQueryServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{SlowQueryThreshold: -1},
+			5*time.Second,
+			6*time.Second,
+		)
+
+		if strings.Contains(out, "slow REQ") || strings.Contains(out, "slow COUNT") {
+			t.Errorf("slow-query logging should be disabled with negative threshold:\n%s", out)
+		}
+	})
+}
+
+func TestStorageHandler_SlowQuery_CountLogsOnThresholdExceeded(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		out := runSlowQueryServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeCount,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{SlowQueryThreshold: 100 * time.Millisecond},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		for _, want := range []string{
+			`level=WARN`,
+			`msg="storage: slow COUNT"`,
+			`subscription_id=sub1`,
+			`count=1`,
+			`total_ms=`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q\nfull output: %s", want, out)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `StorageHandler` emits a **Warn** log (`"storage: slow REQ"` / `"storage: slow COUNT"`) when a subscription's total duration exceeds `StorageHandlerOptions.SlowQueryThreshold` (default 1s; zero = default, negative = disabled).
- For REQ the log carries `scan_ms` / `send_wait_ms` — time spent outside vs inside `yield`. `iter.Seq` is pull-driven so yield blocking also pauses the storage iterator, but the split still reliably points at *which side owns the stall*.
- `NewStorageHandler(storage)` is now `NewStorageHandler(storage, *StorageHandlerOptions)` (nil = defaults), matching the constructor pattern used elsewhere in the API. Breaking for direct callers but mechanical (`, nil` to every call site).

## Why

Grafana showed p0.99 `QueryDuration` hitting ~10s. Looking at the code path, `QueryDuration` is observed inside `closeFn` which runs after the `for event := range events` loop — so it bundles "Pebble scan time + time spent shipping events to the client." A stalled writeLoop will show up as slow query, which is operationally indistinguishable from a genuinely heavy filter.

The Warn log is the complement to the histogram: the histogram answers *"how often are REQs slow?"*, this log answers *"which REQs, with what shape, and which side owns the latency?"*

- `send_wait_ms >> scan_ms` → stalled client / dead TCP peer / slow consumer
- `scan_ms >> send_wait_ms` → filter / index / data-volume bottleneck
- Both large → broad filter + slow consumer

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all existing tests green)
- [x] 4 new tests in `storage_handler_test.go`:
  - REQ above threshold → log emitted with all expected fields
  - REQ below default 1s → no log
  - Negative threshold → no log even with 5s delay
  - COUNT above threshold → log emitted
- [ ] Operator sanity-check after deploy: confirm Warn logs appear during Grafana latency spikes and carry a useful `scan_ms` / `send_wait_ms` breakdown.

🔍 Generated with [Claude Code](https://claude.com/claude-code)