### PR TITLE
feat: add QueryTimeout to abort long-running REQ / COUNT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,28 @@ This is the complement to the `QueryDuration` histogram: the histogram
 answers "how often are REQs slow?", the Warn log answers "which REQs,
 with what shape, and which side owns the latency?"
 
+**Query abort** (`StorageHandlerOptions.QueryTimeout`):
+
+When the slow-query log is a passive observer, `QueryTimeout` is the
+active enforcement: a REQ or COUNT whose total duration exceeds it is
+*aborted*, not just logged. The handler sends a CLOSED message with
+reason `"error: query timeout"` (no EOSE / COUNT is emitted), the
+context passed to `Storage.Query` is canceled, and the in-progress
+iteration is stopped at the next event boundary. If the slow-query
+log is also enabled, it fires with `completed=false` so the abort
+shows up alongside other slow subscriptions.
+
+Zero (the default) disables the timeout — preserving prior behavior.
+A negative value also disables it. When enabled, set it well above
+`SlowQueryThreshold` so operators see the slow-query log fire and
+have a chance to investigate before the abort kicks in.
+
+Motivating case: a live-but-slow client keeps the WebSocket alive
+(so `ping_timeout` never fires) but drains EVENTs so slowly that a
+broad REQ can stall the pull-driven `iter.Seq` for hours. Without
+this option the relay has no ceiling on REQ wall-time; with it, a
+hard deadline is in place.
+
 ### Metrics
 
 **Observability stance**: metrics and logs are complementary. Logs (from

--- a/storage_handler.go
+++ b/storage_handler.go
@@ -2,6 +2,7 @@ package mocrelay
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"time"
 )
@@ -10,6 +11,10 @@ import (
 // logging a slow REQ / COUNT subscription when
 // [StorageHandlerOptions.SlowQueryThreshold] is zero.
 const DefaultStorageHandlerSlowQueryThreshold = 1 * time.Second
+
+// queryTimeoutCLOSEDReason is the CLOSED message body sent when a REQ or
+// COUNT is aborted by [StorageHandlerOptions.QueryTimeout].
+const queryTimeoutCLOSEDReason = "error: query timeout"
 
 // StorageHandlerOptions configures the storage handler returned by
 // [NewStorageHandler].
@@ -29,6 +34,31 @@ type StorageHandlerOptions struct {
 	// A zero value selects [DefaultStorageHandlerSlowQueryThreshold] (1s).
 	// A negative value disables slow-query logging entirely.
 	SlowQueryThreshold time.Duration
+
+	// QueryTimeout aborts a REQ or COUNT whose total duration exceeds it.
+	// When the timeout fires, the storage handler stops iterating, sends a
+	// CLOSED message with reason "error: query timeout", and returns —
+	// neither the trailing EOSE (for REQ) nor the COUNT reply is emitted.
+	// The slow-query log (if enabled) still fires with completed=false, so
+	// the abort is recorded alongside other slow subscriptions.
+	//
+	// The context passed to Storage.Query is wrapped with
+	// [context.WithTimeout], so any Storage implementation that respects
+	// ctx can short-circuit its own scan; implementations that don't (e.g.
+	// Pebble) are stopped at the next event boundary where the iteration
+	// loop polls ctx.Err.
+	//
+	// The primary use case is a live but slow-consuming client — one that
+	// keeps the WebSocket alive (so ping_timeout never fires) yet drains
+	// EVENTs so slowly that a broad REQ can stall the handler's iterator
+	// for hours. Setting QueryTimeout gives the relay a hard ceiling.
+	//
+	// A zero value disables the timeout (default, preserves prior
+	// behavior). A negative value also disables it. When non-zero, it
+	// should typically be set well above SlowQueryThreshold so the
+	// threshold logs fire first and give operators a chance to observe
+	// slow REQs before they are aborted.
+	QueryTimeout time.Duration
 }
 
 // NewStorageHandler returns a [Handler] that serves EVENT and REQ messages
@@ -45,6 +75,7 @@ type StorageHandlerOptions struct {
 // subscription.
 func NewStorageHandler(storage Storage, opts *StorageHandlerOptions) Handler {
 	threshold := DefaultStorageHandlerSlowQueryThreshold
+	var queryTimeout time.Duration // zero == disabled
 	if opts != nil {
 		switch {
 		case opts.SlowQueryThreshold < 0:
@@ -52,10 +83,14 @@ func NewStorageHandler(storage Storage, opts *StorageHandlerOptions) Handler {
 		case opts.SlowQueryThreshold > 0:
 			threshold = opts.SlowQueryThreshold
 		}
+		if opts.QueryTimeout > 0 {
+			queryTimeout = opts.QueryTimeout
+		}
 	}
 	return NewSimpleHandler(&storageHandler{
 		storage:            storage,
 		slowQueryThreshold: threshold,
+		queryTimeout:       queryTimeout,
 	})
 }
 
@@ -64,6 +99,9 @@ type storageHandler struct {
 	// slowQueryThreshold is the effective threshold for slow-query logging.
 	// Zero means disabled.
 	slowQueryThreshold time.Duration
+	// queryTimeout is the effective abort timeout for REQ / COUNT.
+	// Zero means disabled.
+	queryTimeout time.Duration
 }
 
 func (h *storageHandler) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
@@ -123,6 +161,16 @@ func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Se
 		// (index seek, snapshot creation, etc.) counts toward total.
 		start := time.Now()
 
+		// Apply QueryTimeout by wrapping the context. Storage implementations
+		// that respect ctx will short-circuit; the iteration loop below polls
+		// ctx.Err so implementations that don't (e.g. Pebble) are stopped at
+		// the next event boundary.
+		if h.queryTimeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+			defer cancel()
+		}
+
 		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
 		defer closeFn()
 
@@ -136,8 +184,9 @@ func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Se
 		eventsSent := 0
 
 		// yieldTracked wraps yield so every emission contributes to
-		// sendWait, including the trailing EOSE — which matters when
-		// the stall is on the client side (EOSE never arrives either).
+		// sendWait, including the trailing EOSE / CLOSED — which matters
+		// when the stall is on the client side (the terminal message
+		// never arrives either).
 		yieldTracked := func(m *ServerMsg) bool {
 			s := time.Now()
 			ok := yield(m)
@@ -146,6 +195,13 @@ func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Se
 		}
 
 		for event := range events {
+			// Fast path first: timeout fired while scanning / waiting to
+			// send the previous event. Abort before emitting another one.
+			if ctx.Err() != nil {
+				yieldTracked(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
+				h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
+				return
+			}
 			if !yieldTracked(NewServerEventMsg(msg.SubscriptionID, event)) {
 				h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
 				return
@@ -153,7 +209,15 @@ func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Se
 			eventsSent++
 		}
 
-		// Check for errors after iteration
+		// Distinguish timeout from other errFn failures. Storage impls
+		// that respect ctx may surface context.DeadlineExceeded via
+		// errFn; treat that the same as a ctx.Err-driven abort.
+		if ctx.Err() != nil || errors.Is(errFn(), context.DeadlineExceeded) {
+			yieldTracked(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
+			h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
+			return
+		}
+
 		if err := errFn(); err != nil {
 			LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err, "subscription_id", msg.SubscriptionID)
 			yieldTracked(NewServerEOSEMsg(msg.SubscriptionID))
@@ -179,12 +243,29 @@ func (h *storageHandler) handleCount(ctx context.Context, msg *ClientMsg) (iter.
 		// iterator-initialization cost counts toward total.
 		start := time.Now()
 
+		if h.queryTimeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+			defer cancel()
+		}
+
 		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
 		defer closeFn()
 
 		count := uint64(0)
 		for range events {
+			if ctx.Err() != nil {
+				yield(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
+				h.maybeLogSlowCount(ctx, msg, start, count)
+				return
+			}
 			count++
+		}
+
+		if ctx.Err() != nil || errors.Is(errFn(), context.DeadlineExceeded) {
+			yield(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
+			h.maybeLogSlowCount(ctx, msg, start, count)
+			return
 		}
 
 		if err := errFn(); err != nil {

--- a/storage_handler_test.go
+++ b/storage_handler_test.go
@@ -504,3 +504,198 @@ func TestStorageHandler_SlowQuery_CountLogsOnThresholdExceeded(t *testing.T) {
 		}
 	})
 }
+
+// runQueryTimeoutServeNostr mirrors runSlowQueryServeNostr but also drains the
+// send channel after cancel, so tests can assert which terminal ServerMsg
+// (CLOSED on timeout, EOSE / COUNT on normal completion) was emitted.
+func runQueryTimeoutServeNostr(
+	t *testing.T,
+	msg *ClientMsg,
+	opts *StorageHandlerOptions,
+	delay time.Duration,
+	advance time.Duration,
+) (string, []*ServerMsg) {
+	t.Helper()
+	ctx := context.Background()
+	base := NewInMemoryStorage()
+	base.Store(ctx, makeEvent("event-1", "pubkey01", 1, 100))
+
+	storage := &delayedQueryStorage{inner: base, delay: delay}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	handler := NewStorageHandler(storage, opts)
+
+	ctx = ContextWithLogger(ctx, logger)
+	ctx, cancel := context.WithCancel(ctx)
+
+	send := make(chan *ServerMsg, 10)
+	recv := make(chan *ClientMsg, 10)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- handler.ServeNostr(ctx, send, recv) }()
+
+	recv <- msg
+
+	time.Sleep(advance)
+	synctest.Wait()
+
+	cancel()
+	synctest.Wait()
+	<-errCh
+
+	var msgs []*ServerMsg
+drain:
+	for {
+		select {
+		case m := <-send:
+			msgs = append(msgs, m)
+		default:
+			break drain
+		}
+	}
+	return buf.String(), msgs
+}
+
+func TestStorageHandler_QueryTimeout_ReqAbortsWithClosed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		out, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{
+				SlowQueryThreshold: 50 * time.Millisecond,
+				QueryTimeout:       100 * time.Millisecond,
+			},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		// Must have sent exactly one CLOSED, no EVENT or EOSE.
+		require.Len(t, msgs, 1)
+		assert.Equal(t, MsgTypeClosed, msgs[0].Type)
+		assert.Equal(t, "sub1", msgs[0].SubscriptionID)
+		assert.Equal(t, "error: query timeout", msgs[0].Message)
+
+		// Slow-query log should fire with completed=false (aborted).
+		for _, want := range []string{
+			`msg="storage: slow REQ"`,
+			`completed=false`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q\nfull output: %s", want, out)
+			}
+		}
+	})
+}
+
+func TestStorageHandler_QueryTimeout_CountAbortsWithClosed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeCount,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{QueryTimeout: 100 * time.Millisecond},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		require.Len(t, msgs, 1)
+		assert.Equal(t, MsgTypeClosed, msgs[0].Type)
+		assert.Equal(t, "sub1", msgs[0].SubscriptionID)
+		assert.Equal(t, "error: query timeout", msgs[0].Message)
+	})
+}
+
+func TestStorageHandler_QueryTimeout_ReqWithinTimeoutNormalEose(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{QueryTimeout: 5 * time.Second},
+			50*time.Millisecond,
+			100*time.Millisecond,
+		)
+
+		// Normal completion: 1 EVENT + EOSE, no CLOSED.
+		require.Len(t, msgs, 2)
+		assert.Equal(t, MsgTypeEvent, msgs[0].Type)
+		assert.Equal(t, MsgTypeEOSE, msgs[1].Type)
+	})
+}
+
+func TestStorageHandler_QueryTimeout_CountWithinTimeoutNormalCount(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeCount,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{QueryTimeout: 5 * time.Second},
+			50*time.Millisecond,
+			100*time.Millisecond,
+		)
+
+		require.Len(t, msgs, 1)
+		assert.Equal(t, MsgTypeCount, msgs[0].Type)
+		assert.Equal(t, uint64(1), msgs[0].Count)
+	})
+}
+
+func TestStorageHandler_QueryTimeout_ZeroDisables(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Large delay that would trip any positive timeout, but zero
+		// QueryTimeout means disabled.
+		_, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{
+				SlowQueryThreshold: -1, // silence the slow-query log
+				QueryTimeout:       0,  // explicitly disabled
+			},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		// Normal completion despite long delay: EVENT + EOSE.
+		require.Len(t, msgs, 2)
+		assert.Equal(t, MsgTypeEvent, msgs[0].Type)
+		assert.Equal(t, MsgTypeEOSE, msgs[1].Type)
+	})
+}
+
+func TestStorageHandler_QueryTimeout_NegativeDisables(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, msgs := runQueryTimeoutServeNostr(t,
+			&ClientMsg{
+				Type:           MsgTypeReq,
+				SubscriptionID: "sub1",
+				Filters:        []*ReqFilter{{}},
+			},
+			&StorageHandlerOptions{
+				SlowQueryThreshold: -1,
+				QueryTimeout:       -1 * time.Second,
+			},
+			500*time.Millisecond,
+			600*time.Millisecond,
+		)
+
+		require.Len(t, msgs, 2)
+		assert.Equal(t, MsgTypeEvent, msgs[0].Type)
+		assert.Equal(t, MsgTypeEOSE, msgs[1].Type)
+	})
+}


### PR DESCRIPTION
## Summary
- Add `StorageHandlerOptions.QueryTimeout` — when a REQ or COUNT exceeds it, the handler sends `CLOSED "error: query timeout"`, cancels the ctx passed to `Storage.Query`, and stops iterating at the next event boundary (no EOSE / COUNT is emitted).
- Slow-query log (from #72) still fires with `completed=false` when the abort kicks in, so the same Warn feed records both passive-observation and active-enforcement cases.
- Zero (default) / negative disables — preserves prior behavior.

## Why
Production logs on salmon right after #72 landed showed REQs with `total_ms=9472671` (~**2h38m**), `send_wait_ms ≈ total_ms`, `scan_ms ≈ 0`: a live-but-slow client keeping the WebSocket alive (so `ping_timeout` never fires) while draining EVENTs so slowly that the pull-driven `iter.Seq` stalled for hours. `QueryTimeout` puts a hard ceiling on REQ wall-time for exactly that case.

## Test plan
- [x] `go test -count=1 ./...` — all existing tests still pass
- [x] 6 new tests cover: REQ abort sends CLOSED (no EVENT/EOSE after), COUNT abort sends CLOSED, below-timeout normal EOSE / COUNT, zero disables, negative disables, slow-query log fires with `completed=false` on abort
- [ ] Operator verification on salmon after rollout (enable with a conservative timeout, confirm the 2h38m class of REQs gets aborted without tripping legitimate-but-heavy queries)

⏱ Generated with [Claude Code](https://claude.com/claude-code)