### PR TITLE
feat: render REQ/COUNT filters as JSON in slow-query logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,36 @@ Notes on retracted gaps:
   recv-buffer-full drop (`recv_buf_full`) in a single counter. The
   broader name reflects the broader coverage.
 
+#### Metric name mapping (Go field ↔ Prometheus)
+
+The **Existing** column above lists Go struct field names from the
+various `*Metrics` Options structs (e.g. `QueryDuration`,
+`MessagesReceived`). These correspond to Prometheus time series under
+the `mocrelay_` prefix, lower-snake-cased, with the standard suffix of
+the instrument type (`_total`, `_seconds`, `_current`, or none for
+Histograms which emit `_bucket` / `_count` / `_sum`). Examples:
+
+| Go field | Prometheus time series |
+|---|---|
+| `QueryDuration` | `mocrelay_query_duration_seconds` |
+| `StoreDuration` | `mocrelay_store_duration_seconds` |
+| `QueryErrors` | `mocrelay_query_errors_total` |
+| `WSWriteDuration` | `mocrelay_ws_write_duration_seconds` |
+| `WSWriteErrors{reason}` | `mocrelay_ws_write_errors_total{reason}` |
+| `MessagesReceived{type}` | `mocrelay_messages_received_total{type}` |
+| `EventsStored{kind, type, stored}` | `mocrelay_events_stored_total{kind, type, stored}` |
+| `AuthTotal{result}` | `mocrelay_auth_total{result}` |
+| `AuthenticatedConnectionsCurrent` | `mocrelay_auth_authenticated_connections_current` |
+| `SearchTotal` / `IndexTotal` | `mocrelay_search_total` / `mocrelay_index_total` |
+| `MessagesDropped` | `mocrelay_router_messages_dropped_total` |
+| `LostChildrenTotal` | `mocrelay_merge_lost_children_total` |
+
+The authoritative list is `metrics.go`. Notably there is **no
+`storage_` infix** for StorageHandler metrics — the series are flat
+(`mocrelay_query_duration_seconds`, `mocrelay_store_errors_total`,
+…), not `mocrelay_storage_query_*`. PromQL that naïvely prefixes with
+`storage` will match nothing.
+
 #### Known concerns (decide before v0.x freeze)
 
 1. **`kind` label explosion** — **implemented: two-axis label

--- a/filter.go
+++ b/filter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
+	"log/slog"
 	"slices"
 )
 
@@ -144,6 +145,25 @@ func (f *ReqFilter) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(obj)
+}
+
+// reqFiltersLogValue returns a slog.Value that renders a []*ReqFilter as a
+// single compact JSON array (the Nostr wire form). Used by StorageHandler
+// slow-query logs and similar operator-facing diagnostics where the filter
+// shape (ids, authors, kinds, tags, since, until, limit, search) is the
+// key observation.
+//
+// Kept unexported, and intentionally **not** paired with a slog.LogValuer
+// method on *ReqFilter: exposing either would grow the public API surface
+// without an external use case today. External callers who want the same
+// rendering can json.Marshal(filter) themselves, which the public
+// MarshalJSON already supports.
+func reqFiltersLogValue(filters []*ReqFilter) slog.Value {
+	b, err := json.Marshal(filters)
+	if err != nil {
+		return slog.StringValue(fmt.Sprintf("(marshal error: %v)", err))
+	}
+	return slog.StringValue(string(b))
 }
 
 // Valid checks if the filter has valid format.

--- a/filter_test.go
+++ b/filter_test.go
@@ -6,6 +6,22 @@ import (
 	"time"
 )
 
+// jsonStringEqual is a small convenience that decodes two JSON strings
+// and compares them via the package-level jsonEqual helper (defined in
+// message_test.go), so tests can assert on JSON *shape* without pinning
+// the unstable map key order from encoding/json/v2.
+func jsonStringEqual(t *testing.T, got, want string) bool {
+	t.Helper()
+	var g, w any
+	if err := json.Unmarshal([]byte(got), &g); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal([]byte(want), &w); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	return jsonEqual(g, w)
+}
+
 func TestReqFilter_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -363,5 +379,70 @@ func TestIsValidLowercaseHex(t *testing.T) {
 		if got := isValidLowercaseHex(tt.s, tt.length); got != tt.want {
 			t.Errorf("isValidLowercaseHex(%q, %d) = %v, want %v", tt.s, tt.length, got, tt.want)
 		}
+	}
+}
+
+func TestReqFiltersLogValue(t *testing.T) {
+	since := int64(100)
+	until := int64(200)
+	limit := int64(50)
+	search := "hello"
+
+	tests := []struct {
+		name    string
+		filters []*ReqFilter
+		want    string // compared with jsonStringEqual; v2 map key order is unstable
+	}{
+		{
+			// encoding/json/v2 marshals a nil slice as "[]" (not "null"
+			// like v1). Either rendering is fine for this log — the
+			// operator just needs to see "no filters".
+			name:    "nil slice renders as empty JSON array",
+			filters: nil,
+			want:    `[]`,
+		},
+		{
+			name:    "empty slice renders as empty JSON array",
+			filters: []*ReqFilter{},
+			want:    `[]`,
+		},
+		{
+			name:    "slice containing an empty filter renders as [{}]",
+			filters: []*ReqFilter{{}},
+			want:    `[{}]`,
+		},
+		{
+			name: "populated filter carries every non-zero field",
+			filters: []*ReqFilter{
+				{
+					IDs:     []string{"aa"},
+					Authors: []string{"bb"},
+					Kinds:   []int64{1, 7},
+					Tags:    map[string][]string{"e": {"cc"}},
+					Since:   &since,
+					Until:   &until,
+					Limit:   &limit,
+					Search:  &search,
+				},
+			},
+			want: `[{"#e":["cc"],"authors":["bb"],"ids":["aa"],"kinds":[1,7],"limit":50,"search":"hello","since":100,"until":200}]`,
+		},
+		{
+			name: "multi-filter slice preserves order and per-filter shape",
+			filters: []*ReqFilter{
+				{Kinds: []int64{1}},
+				{Authors: []string{"ab"}, Limit: &limit},
+			},
+			want: `[{"kinds":[1]},{"authors":["ab"],"limit":50}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reqFiltersLogValue(tt.filters).String()
+			if !jsonStringEqual(t, got, tt.want) {
+				t.Errorf("reqFiltersLogValue() = %q, want (JSON-equal to) %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/storage_handler.go
+++ b/storage_handler.go
@@ -219,7 +219,7 @@ func (h *storageHandler) maybeLogSlowReq(
 	scan := max(total-sendWait, 0)
 	LoggerFromContext(ctx).WarnContext(ctx, "storage: slow REQ",
 		"subscription_id", msg.SubscriptionID,
-		"filters", msg.Filters,
+		"filters", reqFiltersLogValue(msg.Filters),
 		"events_sent", eventsSent,
 		"total_ms", total.Milliseconds(),
 		"scan_ms", scan.Milliseconds(),
@@ -245,7 +245,7 @@ func (h *storageHandler) maybeLogSlowCount(
 	}
 	LoggerFromContext(ctx).WarnContext(ctx, "storage: slow COUNT",
 		"subscription_id", msg.SubscriptionID,
-		"filters", msg.Filters,
+		"filters", reqFiltersLogValue(msg.Filters),
 		"count", count,
 		"total_ms", total.Milliseconds(),
 	)


### PR DESCRIPTION
## Summary

- Slow REQ / COUNT Warn logs (added in #72) previously emitted `filters=[0xc0005d5880]` — the default `fmt` rendering of a `[]*ReqFilter` — so operators had no way to see the actual filter shape, which is exactly what the slow-query log is supposed to surface.
- Add an **unexported** `reqFiltersLogValue([]*ReqFilter) slog.Value` helper that marshals the slice via the existing public `MarshalJSON`, producing the compact JSON wire form, and wire it into the two slow-query log sites in `storage_handler.go`.
- Deliberately kept non-public (no `slog.LogValuer` on `*ReqFilter` either) to avoid growing v0.x public API surface without an external use case.
- Bonus: add a Go-field ↔ Prometheus-metric mapping table to CLAUDE.md, calling out that StorageHandler metrics are flat (`mocrelay_query_*`, `mocrelay_store_*`) with **no `storage_` infix**.

## Why now

Investigating today's slow-query alerts on salmon, the Warn log looked like:

```
time=2026-04-20T20:42:43.169+09:00 level=WARN msg="storage: slow REQ"
  conn_id=... subscription_id=913598:0
  filters=[0xc0007f33b0]    ← can't see the shape
  events_sent=33 total_ms=195941 scan_ms=1 send_wait_ms=195939 completed=false
```

The timing / scan / send-wait breakdown was perfect, but the `filters=[0xc...]` line was useless — exactly the field an operator wants to read first to decide whether a broad filter is the cause or a slow consumer is.

With this PR the same log becomes:

```
filters=[{"kinds":[1],"authors":["..."],"limit":500}]
```

Separately, the investigation tripped over a CLAUDE.md wording issue: the Coverage-by-layer table described Storage metrics as "Storage / QueryDuration" etc. in Go-field notation, which led me to write PromQL like `mocrelay_storage_query_duration_seconds_bucket` — and get zero results, because the real metric is `mocrelay_query_duration_seconds_bucket` (no `storage_`). The new mapping table spells the Go↔Prometheus correspondence out so the next PromQL author (very likely me) doesn't walk into the same rake.

## Changes

| File | Change |
|---|---|
| `filter.go` | Unexported helper `reqFiltersLogValue([]*ReqFilter) slog.Value` (+ doc comment explaining the unexported choice) |
| `storage_handler.go` | Wrap `msg.Filters` in the helper at the two slow-query log sites (slow REQ, slow COUNT) |
| `filter_test.go` | Table-driven tests covering nil slice / empty slice / `[{}]` / populated filter / multi-filter; compares with `jsonStringEqual` helper since `encoding/json/v2` does not stabilize map key order |
| `CLAUDE.md` | New "Metric name mapping" subsection under Metrics with a Go-field↔Prometheus table and the `no storage_ infix` note |

Public API: **zero new exports**.

## Test plan

- [x] `go test ./...` passes (full suite, incl. existing storage_handler / filter tests)
- [x] `go vet ./...` clean
- [x] `lefthook` pre-commit (`go fix` + `go fmt`) clean
- [ ] After merge / auto-tag: deploy to salmon, wait for the next live-but-slow client, and verify the new Warn log carries the JSON filter
- [ ] Operator sanity: `journalctl -u mocrelay-jp | rg 'slow REQ'` should show a readable `filters=[{...}]` instead of pointer syntax

🔍 Generated with [Claude Code](https://claude.com/claude-code)