### PR TITLE
feat!: unify Prometheus registration under *Options.Registerer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,8 +272,9 @@ review time, the label is probably too cardinal.
 `logRejection` is the single place where every middleware reports a
 rejection. It performs two side-effects from the same call site:
 
-1. Increments `mocrelay_rejections_total{middleware, reason}` via the
-   context-injected [RejectionMetrics] (no-op if absent).
+1. Increments the context-injected `mocrelay_rejections_total{middleware,
+   reason}` counter (installed by `Relay` when `RelayOptions.Registerer`
+   is set; no-op if absent).
 2. Emits a Debug-level structured log entry with the same `middleware`
    and `reason` fields.
 
@@ -296,56 +297,78 @@ The `middleware` axis lets operators scope further:
 | **Gauge** | Current level (connections, subscriptions, buffer depth) | Must have matched Inc / Dec (`defer`, cleanup, or `Set`) or it drifts upward forever |
 | **Histogram** | Latency / size distributions where the tail matters | More expensive than Counter; acceptable per REQ / per Store. For per-EVENT hot paths, audit buckets first |
 
-#### Nil-safe injection
+#### Registerer injection
 
-Metrics are optional, matching the philosophy of `Relay.Logger`. Two
-injection shapes coexist:
+Metrics are optional, matching the philosophy of `Relay.Logger`. Every
+component that owns instrumented behavior exposes a single
+`Registerer prometheus.Registerer` field on its `*Options` struct:
 
-- **Per-owner options** (`RelayMetrics`, `RouterMetrics`,
-  `StorageMetrics`, `MergeHandlerMetrics`, `CompositeStorageMetrics`):
-  passed through the owning
-  type's `*Options` struct. `nil` means "don't measure, don't allocate."
-  Call sites guard with a nil check so the instrument-free build path
-  has zero runtime cost and no Prometheus dependency surface. These
-  are all measured by the owning type itself (Relay measures Relay,
-  Storage measures Storage, …), so there is nothing request-scoped to
-  propagate — Options is the right place.
-- **Context-injected** (`RejectionMetrics`, `AuthMetrics`): threaded
-  through the request context, symmetric with `Logger`. `Relay`
-  installs them once per connection from `RelayOptions.RejectionMetrics`
-  / `RelayOptions.AuthMetrics`; middleware never holds a reference,
-  never needs a nil check — the middleware reads them via
-  `RejectionMetricsFromContext` / `AuthMetricsFromContext` and no-ops
-  on nil. The rule for picking this shape over Options is "the metric
-  is consumed by a unit that composes *into* a Relay
-  (handler / middleware), rather than by the unit itself." Logger
-  follows the same rule, which is why it shares the ctx path.
+- `RelayOptions.Registerer` — Relay's own conn / message / event
+  counters, *plus* the request-ctx-injected rejection and auth
+  counters (one field, three metric families registered).
+- `RouterOptions.Registerer` — router saturation.
+- `CompositeStorageOptions.Registerer` — search / index RED.
+- `MergeHandlerOptions.Registerer` — merge-handler USE.
+- `NewMetricsStorage(storage, reg)` — Storage RED (decorator, no
+  Options struct; see Constructor API exceptions below).
 
-Just as `Logger == nil` falls back to `slog.Default()`, both
-`Metrics == nil` and a ctx without `RejectionMetrics` / `AuthMetrics`
-fall back to silence.
+Setting the field causes the constructor to build and register every
+metric the component owns in one shot. Leaving it nil disables
+instrumentation: no collectors are created, every instrument site
+short-circuits on a nil check, and no Prometheus code runs on the
+hot path. The authoritative list of what each `Registerer` registers
+lives in `metrics.go`.
+
+Two consumption shapes coexist under the same field, determined by
+whether the metric's natural consumer is the owning type itself or
+something composed *into* a Relay:
+
+- **Self-owned** — Relay's own WS counters, Router, Composite, Merge,
+  the Storage decorator. The constructor builds the metrics struct
+  internally and the owning type calls into it directly.
+- **Ctx-injected** — the rejection and auth counters. The `Relay`
+  constructor builds both structs from `RelayOptions.Registerer`,
+  installs them into every request context, and the consuming
+  middleware reads them back via internal helpers — mirroring the
+  `ContextWithLogger` pattern. Middleware code never holds a
+  reference and never nil-checks. The rule for picking the ctx path
+  is "the metric's natural consumer is a unit that composes *into* a
+  Relay, rather than the Relay itself."
+
+These structs (`relayMetrics`, `rejectionMetrics`, `authMetrics`,
+etc.) and the accompanying `contextWith…` / `…FromContext` helpers
+are all unexported: the public API surface is just the `Registerer`
+field on each Options struct. Subregistry use cases
+(`prometheus.WrapRegistererWithPrefix`, etc.) compose naturally — wrap
+the registry and hand the wrapper in.
+
+Just as `Logger == nil` falls back to `slog.Default()`, every
+`Registerer == nil` path falls back to silence.
 
 `MergeHandlerMetrics` is the next candidate to consider for the
-context-injected set under the same rule (consumed by a handler that
-composes into Relay rather than by Relay itself). It is left on
-Options for now; a follow-up PR can evaluate the move once a concrete
-need arises.
+ctx-injected path under the same rule (a handler that composes into
+Relay rather than the Relay itself). It stays self-owned for now; a
+follow-up PR can evaluate the move once a concrete need arises.
 
 #### Coverage by layer (drives follow-up PRs)
 
+Series names below are the Prometheus metric names (all prefixed
+`mocrelay_`). The authoritative mapping to internal Go fields is in
+`metrics.go`; there is no `*Metrics` public type to reference.
+
 | Layer | Kind | Existing | Gaps (future PRs) |
 |---|---|---|---|
-| **Relay (WS conn)** | RED-R | `ConnectionsTotal`, `MessagesReceived{type}`, `MessagesSent{type}`, `EventsReceived{kind, type}` | — |
-| | RED-E | `WSParseErrors{reason}`, `WSWriteErrors{reason}` | — |
-| | RED-D | `WSWriteDuration` | — |
-| | USE-Sat | `ConnectionsCurrent` | — (see note below) |
-| **Router** | USE-Sat | `MessagesDropped`, `SubscriptionsCurrent` | — |
-| **Middleware: Auth** | RED-R+E | `AuthTotal{result}`, `AuthenticatedConnectionsCurrent`, rejections via unified `mocrelay_rejections_total{middleware="auth", reason}` | — |
-| **Middleware: others (10)** | RED-E | Rejections via unified `mocrelay_rejections_total{middleware, reason}` (wired automatically through `logRejection`) | — |
-| **StorageHandler** | RED-R+D+E | `EventsStored{kind, type, stored}`, `Store / QueryDuration`, `StoreErrors`, `QueryErrors` | — |
-| **MergeHandler** | USE-Sat+E | `LostChildrenTotal`, `BroadcastTimeoutsTotal`, `EventDrops{reason}` | — |
+| **Relay (WS conn)** | RED-R | `connections_total`, `messages_received_total{type}`, `messages_sent_total{type}`, `events_received_total{kind, type}` | — |
+| | RED-E | `ws_parse_errors_total{reason}`, `ws_write_errors_total{reason}` | — |
+| | RED-D | `ws_write_duration_seconds` | — |
+| | USE-Sat | `connections_current` | — (see note below) |
+| **Router** | USE-Sat | `router_messages_dropped_total`, `router_subscriptions_current` | — |
+| **Middleware: Auth** | RED-R+E | `auth_total{result}`, `auth_authenticated_connections_current`, rejections via unified `rejections_total{middleware="auth", reason}` | — |
+| **Middleware: others (10)** | RED-E | Rejections via unified `rejections_total{middleware, reason}` (wired automatically through `logRejection`) | — |
+| **StorageHandler** | RED-R+D+E | `events_stored_total{kind, type, stored}`, `store_duration_seconds`, `query_duration_seconds`, `store_errors_total`, `query_errors_total` | — |
+| **MergeHandler** | USE-Sat+E | `merge_lost_children_total`, `merge_broadcast_timeouts_total`, `merge_event_drops_total{reason}` | — |
 | **Pebble (internals)** | USE | — (caller-owned) | External: expose via caller's `*pebble.DB` — `db.Metrics()` → L0 files, compactions, WAL bytes |
-| **Bleve / SearchIndex (via CompositeStorage)** | RED-R+E | `SearchTotal`, `SearchErrors`, `IndexTotal`, `IndexErrors` (on `CompositeStorageMetrics`) | — |
+| **Bleve / SearchIndex (via CompositeStorage)** | RED-R+E | `search_total`, `search_errors_total`, `index_total`, `index_errors_total` | — |
 | | USE | — (caller-owned) | External: expose via caller's `bleve.Index` — `idx.StatsMap()` → doc count, batch stats |
 
 Notes on retracted gaps:
@@ -367,34 +390,22 @@ Notes on retracted gaps:
   recv-buffer-full drop (`recv_buf_full`) in a single counter. The
   broader name reflects the broader coverage.
 
-#### Metric name mapping (Go field ↔ Prometheus)
+#### Metric naming conventions
 
-The **Existing** column above lists Go struct field names from the
-various `*Metrics` Options structs (e.g. `QueryDuration`,
-`MessagesReceived`). These correspond to Prometheus time series under
-the `mocrelay_` prefix, lower-snake-cased, with the standard suffix of
-the instrument type (`_total`, `_seconds`, `_current`, or none for
-Histograms which emit `_bucket` / `_count` / `_sum`). Examples:
+All Prometheus series emitted by mocrelay use the `mocrelay_` prefix
+with standard instrument-type suffixes (`_total` for Counters,
+`_seconds` for duration Histograms, `_current` for Gauges tracking
+level, unsuffixed for plain Counters measuring sizes / offsets).
+Internal Go fields in `metrics.go` follow the unsuffixed,
+CamelCase counterpart (e.g. the Go field `QueryDuration` drives the
+series `mocrelay_query_duration_seconds`), but the fields are
+unexported: the authoritative list is the constructor body of each
+`new*Metrics` function.
 
-| Go field | Prometheus time series |
-|---|---|
-| `QueryDuration` | `mocrelay_query_duration_seconds` |
-| `StoreDuration` | `mocrelay_store_duration_seconds` |
-| `QueryErrors` | `mocrelay_query_errors_total` |
-| `WSWriteDuration` | `mocrelay_ws_write_duration_seconds` |
-| `WSWriteErrors{reason}` | `mocrelay_ws_write_errors_total{reason}` |
-| `MessagesReceived{type}` | `mocrelay_messages_received_total{type}` |
-| `EventsStored{kind, type, stored}` | `mocrelay_events_stored_total{kind, type, stored}` |
-| `AuthTotal{result}` | `mocrelay_auth_total{result}` |
-| `AuthenticatedConnectionsCurrent` | `mocrelay_auth_authenticated_connections_current` |
-| `SearchTotal` / `IndexTotal` | `mocrelay_search_total` / `mocrelay_index_total` |
-| `MessagesDropped` | `mocrelay_router_messages_dropped_total` |
-| `LostChildrenTotal` | `mocrelay_merge_lost_children_total` |
-
-The authoritative list is `metrics.go`. Notably there is **no
-`storage_` infix** for StorageHandler metrics — the series are flat
-(`mocrelay_query_duration_seconds`, `mocrelay_store_errors_total`,
-…), not `mocrelay_storage_query_*`. PromQL that naïvely prefixes with
+Notable gotcha: there is **no `storage_` infix** for StorageHandler
+series. They are flat — `mocrelay_query_duration_seconds`,
+`mocrelay_store_errors_total`, etc. — not
+`mocrelay_storage_query_*`. PromQL that naïvely prefixes with
 `storage` will match nothing.
 
 #### Known concerns (decide before v0.x freeze)
@@ -449,16 +460,18 @@ The authoritative list is `metrics.go`. Notably there is **no
    `(kind, type)` two-axis label.
 
    Implementation:
-   - `RejectionMetrics` lives in `metrics.go`; it wraps a single
+   - The unified counter lives in `metrics.go` as the internal
+     `rejectionMetrics` struct, wrapping a single
      `mocrelay_rejections_total` CounterVec.
-   - `Relay` installs it into the request context via
-     `ContextWithRejectionMetrics`, symmetric with `ContextWithLogger`.
+   - `Relay` builds and registers it from `RelayOptions.Registerer`
+     and installs it into the request context, mirroring
+     `ContextWithLogger`.
    - `logRejection` reads it from context on every call and increments
      `{middleware, reason}` alongside its Debug log line. Middleware
      authors don't touch metrics code at all.
-   - `AuthMetrics.RejectionsTotal` was removed as part of this pivot;
-     its auth-specific reasons (`event_unauthenticated`, `expired`, …)
-     now land on the unified counter with `middleware="auth"`.
+   - Auth-specific rejection reasons (`event_unauthenticated`,
+     `expired`, …) land on the unified counter with `middleware="auth"`;
+     there is no separate per-middleware rejection metric.
 
    Rejected alternatives: per-middleware `*Options` with a `Metrics`
    field (API bloat across 10 middleware, constructor signature churn
@@ -527,14 +540,12 @@ Rules:
   does not re-check for zero values. Writing `if x == 0 { x = default }`
   at call sites is a smell — it means the constructor did not finish
   its job.
-- **Metrics are a field of some `*Options` struct**, not a separate
-  positional arg or a post-construction field. Which Options depends on
-  the consumer: types that measure themselves (e.g. `RouterMetrics` on
-  `RouterOptions`) keep Metrics on their own Options; types that are
-  composed *into* `Relay` and measured while serving a request
-  (`AuthMetrics`, `RejectionMetrics`) put Metrics on `RelayOptions` and
-  let `Relay` install them into the request context. See the "Nil-safe
-  injection" section in the Metrics policy above for the full rule.
+- **Prometheus registration is a single `Registerer` field on `*Options`**,
+  never a separate positional arg or a post-construction field.
+  Each component owns the metrics it registers; metrics whose natural
+  consumer is a middleware (rejection, auth) are registered by the
+  Relay and ctx-injected. See the "Registerer injection" section in
+  the Metrics policy above for the full rule.
 
 This pattern is used by `NewRelay`, `NewRouter`, `NewAuthMiddlewareBase`,
 `NewPebbleStorage`, `NewBleveIndex`, `NewCompositeStorage`, and
@@ -544,10 +555,14 @@ same shape so third-party code composing with mocrelay has a predictable
 surface.
 
 Exceptions:
-- `MetricsStorage` uses the decorator pattern (`NewMetricsStorage(storage, metrics)`)
+- `MetricsStorage` uses the decorator pattern
+  (`NewMetricsStorage(storage Storage, reg prometheus.Registerer)`)
   because `Storage` is an interface with multiple implementations
   (InMemory / Pebble / Composite) and a decorator is the natural way
-  to inject cross-cutting behavior.
+  to inject cross-cutting behavior. It takes the Registerer
+  positionally rather than through an Options struct; `reg == nil` is
+  valid and makes every call pass straight through to the wrapped
+  storage.
 - Middlewares whose *entire* configuration is required (e.g.
   `NewMaxLimitMiddlewareBase(maxLimit, defaultLimit int64)`) skip the
   Options struct because there is nothing optional to collect.

--- a/cmd/examples/kitchen-sink/main.go
+++ b/cmd/examples/kitchen-sink/main.go
@@ -50,14 +50,16 @@ func main() {
 	}))
 
 	// --- Prometheus registry ---
+	//
+	// mocrelay exposes a single `Registerer` field on each *Options struct.
+	// Setting it causes that component to register its metrics with the
+	// supplied registry; leaving it nil disables instrumentation entirely
+	// for that component (no collectors are created and every instrument
+	// site no-ops). Pass the same registry to every component to collect
+	// everything under one Prometheus registry.
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	relayMetrics := mocrelay.NewRelayMetrics(reg)
-	routerMetrics := mocrelay.NewRouterMetrics(reg)
-	authMetrics := mocrelay.NewAuthMetrics(reg)
-	storageMetrics := mocrelay.NewStorageMetrics(reg)
-	compositeMetrics := mocrelay.NewCompositeStorageMetrics(reg)
 
 	// --- Storage layer ---
 	//
@@ -102,16 +104,16 @@ func main() {
 
 	// Composite: Pebble (source of truth) + Bleve (search).
 	compositeStorage := mocrelay.NewCompositeStorage(pebbleStorage, bleveIndex, &mocrelay.CompositeStorageOptions{
-		Metrics: compositeMetrics,
+		Registerer: reg,
 	})
 
 	// Metrics: wrap storage with Prometheus instrumentation.
-	storage := mocrelay.NewMetricsStorage(compositeStorage, storageMetrics)
+	storage := mocrelay.NewMetricsStorage(compositeStorage, reg)
 
 	// --- Routing layer ---
 
 	router := mocrelay.NewRouter(&mocrelay.RouterOptions{
-		Metrics: routerMetrics,
+		Registerer: reg,
 	})
 
 	// --- Handler ---
@@ -128,8 +130,9 @@ func main() {
 
 	handler = mocrelay.NewSimpleMiddleware(
 		// Auth (NIP-42): challenge/response authentication.
-		// AuthMetrics is injected via RelayOptions.AuthMetrics below,
-		// picked up by the middleware via AuthMetricsFromContext.
+		// Auth metrics are constructed by Relay from RelayOptions.Registerer
+		// (below) and injected into the request context; the middleware
+		// reads them internally.
 		mocrelay.NewAuthMiddlewareBase("wss://relay.example.com/", nil),
 
 		// Protected events (NIP-70): prevent republishing "-" tagged events.
@@ -158,9 +161,8 @@ func main() {
 	// --- Relay ---
 
 	relay := mocrelay.NewRelay(handler, &mocrelay.RelayOptions{
-		Logger:      logger,
-		Metrics:     relayMetrics,
-		AuthMetrics: authMetrics,
+		Logger:     logger,
+		Registerer: reg,
 		Info: &mocrelay.RelayInfo{
 			Name:          "mocrelay-kitchen-sink",
 			Description:   "A full-featured Nostr relay example",

--- a/composite_storage.go
+++ b/composite_storage.go
@@ -3,6 +3,8 @@ package mocrelay
 import (
 	"context"
 	"iter"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // CompositeStorage combines a primary Storage with a SearchIndex.
@@ -26,16 +28,22 @@ import (
 type CompositeStorage struct {
 	primary Storage
 	search  SearchIndex
-	metrics *CompositeStorageMetrics
+	metrics *compositeStorageMetrics
 }
 
 // CompositeStorageOptions configures [CompositeStorage]. Pass nil for
 // defaults.
 type CompositeStorageOptions struct {
-	// Metrics collects search and indexing observability signals. nil
-	// disables instrumentation (zero runtime cost, no Prometheus
-	// dependency on the caller).
-	Metrics *CompositeStorageMetrics
+	// Registerer is the Prometheus registry that CompositeStorage's
+	// internal search / indexing counters are registered with
+	// (mocrelay_search_total, mocrelay_search_errors_total,
+	// mocrelay_index_total, mocrelay_index_errors_total). If nil, no
+	// metrics are collected (zero runtime cost at each instrument site).
+	//
+	// The underlying Bleve / SearchIndex resource state itself (doc count,
+	// index size, batch statistics) lives on the caller's [bleve.Index]
+	// and should be collected directly from idx.StatsMap() by the caller.
+	Registerer prometheus.Registerer
 }
 
 // NewCompositeStorage creates a new CompositeStorage.
@@ -43,14 +51,14 @@ type CompositeStorageOptions struct {
 // search provides full-text search capabilities (can be nil to disable search).
 // opts can be nil; see [CompositeStorageOptions] for configurable options.
 func NewCompositeStorage(primary Storage, search SearchIndex, opts *CompositeStorageOptions) *CompositeStorage {
-	var metrics *CompositeStorageMetrics
+	var reg prometheus.Registerer
 	if opts != nil {
-		metrics = opts.Metrics
+		reg = opts.Registerer
 	}
 	return &CompositeStorage{
 		primary: primary,
 		search:  search,
-		metrics: metrics,
+		metrics: newCompositeStorageMetrics(reg),
 	}
 }
 

--- a/composite_storage_test.go
+++ b/composite_storage_test.go
@@ -269,9 +269,9 @@ func TestCompositeStorage_MetricsSearch(t *testing.T) {
 	search := &fakeSearchIndex{}
 
 	reg := prometheus.NewRegistry()
-	metrics := NewCompositeStorageMetrics(reg)
 
-	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Metrics: metrics})
+	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Registerer: reg})
+	metrics := storage.metrics
 
 	// Prime primary with one event so the fallback path returns something.
 	event := &Event{
@@ -338,9 +338,9 @@ func TestCompositeStorage_MetricsIndex(t *testing.T) {
 	search := &fakeSearchIndex{indexErr: errors.New("index down")}
 
 	reg := prometheus.NewRegistry()
-	metrics := NewCompositeStorageMetrics(reg)
 
-	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Metrics: metrics})
+	storage := NewCompositeStorage(primary, search, &CompositeStorageOptions{Registerer: reg})
+	metrics := storage.metrics
 
 	// Store: primary succeeds, index fails. Store returns success
 	// because indexing is best-effort.

--- a/logger.go
+++ b/logger.go
@@ -24,8 +24,9 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 // logRejection reports a middleware-level message rejection with a uniform
 // key set. It performs two side-effects:
 //
-//  1. Increments the unified [RejectionMetrics] counter from the context
-//     (labels {middleware, reason}) if one is installed. No-op if absent.
+//  1. Increments the unified mocrelay_rejections_total counter from the
+//     context (labels {middleware, reason}) if one is installed. No-op if
+//     absent.
 //  2. Emits a Debug-level structured log entry ("message rejected") so
 //     operators can find all rejections with a single grep.
 //
@@ -37,7 +38,7 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 // logging when investigating why a specific client's messages are being
 // dropped; rely on the metrics counter for day-to-day trends.
 func logRejection(ctx context.Context, middleware, reason string, attrs ...any) {
-	if m := RejectionMetricsFromContext(ctx); m != nil {
+	if m := rejectionMetricsFromContext(ctx); m != nil {
 		m.Total.WithLabelValues(middleware, reason).Inc()
 	}
 	base := []any{"middleware", middleware, "reason", reason}

--- a/logger_test.go
+++ b/logger_test.go
@@ -75,8 +75,8 @@ func TestLogRejection(t *testing.T) {
 
 	t.Run("increments rejection counter from ctx", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		metrics := NewRejectionMetrics(reg)
-		ctx := ContextWithRejectionMetrics(context.Background(), metrics)
+		metrics := newRejectionMetrics(reg)
+		ctx := contextWithRejectionMetrics(context.Background(), metrics)
 
 		logRejection(ctx, "max_content_length", "content_too_long",
 			"event_id", "abc", "length", 9999,
@@ -119,15 +119,15 @@ func TestLogRejection(t *testing.T) {
 
 func TestRejectionMetricsFromContext(t *testing.T) {
 	t.Run("returns nil when not set", func(t *testing.T) {
-		if got := RejectionMetricsFromContext(context.Background()); got != nil {
+		if got := rejectionMetricsFromContext(context.Background()); got != nil {
 			t.Fatalf("expected nil, got %v", got)
 		}
 	})
 
 	t.Run("returns metrics from context", func(t *testing.T) {
-		metrics := NewRejectionMetrics(prometheus.NewRegistry())
-		ctx := ContextWithRejectionMetrics(context.Background(), metrics)
-		if got := RejectionMetricsFromContext(ctx); got != metrics {
+		metrics := newRejectionMetrics(prometheus.NewRegistry())
+		ctx := contextWithRejectionMetrics(context.Background(), metrics)
+		if got := rejectionMetricsFromContext(ctx); got != metrics {
 			t.Fatalf("expected same metrics, got %v", got)
 		}
 	})

--- a/merge_handler.go
+++ b/merge_handler.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // DefaultMergeHandlerBroadcastTimeout is the default per-child broadcast
@@ -140,28 +142,29 @@ type MergeHandlerOptions struct {
 	// A zero value selects [DefaultMergeHandlerBroadcastTimeout] (30s).
 	BroadcastTimeout time.Duration
 
-	// Metrics is the Prometheus metrics collector for merge-handler
-	// saturation and error signals (lost children, broadcast timeouts,
-	// EVENT drops). If nil, no metrics are collected.
-	Metrics *MergeHandlerMetrics
+	// Registerer is the Prometheus registry that merge-handler saturation
+	// and error signals are registered with (mocrelay_merge_lost_children_total,
+	// mocrelay_merge_broadcast_timeouts_total,
+	// mocrelay_merge_event_drops_total). If nil, no metrics are collected.
+	Registerer prometheus.Registerer
 }
 
 // NewMergeHandler returns a [Handler] that fans messages out to every handler
 // in handlers and merges their responses. Pass nil for opts to use defaults.
 func NewMergeHandler(handlers []Handler, opts *MergeHandlerOptions) Handler {
 	timeout := DefaultMergeHandlerBroadcastTimeout
-	var metrics *MergeHandlerMetrics
+	var reg prometheus.Registerer
 	if opts != nil {
 		if opts.BroadcastTimeout > 0 {
 			timeout = opts.BroadcastTimeout
 		}
-		metrics = opts.Metrics
+		reg = opts.Registerer
 	}
 	return &mergeHandler{
 		handlers:         handlers,
 		broadcastTimeout: timeout,
 		childRecvBuffer:  defaultChildRecvBuffer,
-		metrics:          metrics,
+		metrics:          newMergeHandlerMetrics(reg),
 	}
 }
 
@@ -169,7 +172,7 @@ type mergeHandler struct {
 	handlers         []Handler
 	broadcastTimeout time.Duration
 	childRecvBuffer  int
-	metrics          *MergeHandlerMetrics
+	metrics          *mergeHandlerMetrics
 }
 
 func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, recv <-chan *ClientMsg) error {
@@ -355,7 +358,7 @@ type mergeSession struct {
 	pendingEOSEs  map[string]*pendingEOSE  // subscriptionID -> pending EOSE state
 	pendingCounts map[string]*pendingCount // subscriptionID -> pending COUNT state
 	completedSubs map[string]bool          // subscriptionID -> true if EOSE already sent
-	metrics       *MergeHandlerMetrics
+	metrics       *mergeHandlerMetrics
 }
 
 // recordEventDrop increments the merge-handler EVENT drop counter under the
@@ -411,7 +414,7 @@ type pendingEOSE struct {
 	handlerEOSESent []bool
 }
 
-func newMergeSession(numHandlers int, metrics *MergeHandlerMetrics) *mergeSession {
+func newMergeSession(numHandlers int, metrics *mergeHandlerMetrics) *mergeSession {
 	return &mergeSession{
 		numHandlers:   numHandlers,
 		pendingOKs:    make(map[string]*pendingOK),

--- a/metrics.go
+++ b/metrics.go
@@ -6,8 +6,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// RelayMetrics holds Prometheus metrics for Relay.
-type RelayMetrics struct {
+// relayMetrics holds Prometheus metrics for Relay.
+type relayMetrics struct {
 	ConnectionsCurrent prometheus.Gauge
 	ConnectionsTotal   prometheus.Counter
 	MessagesReceived   *prometheus.CounterVec
@@ -31,9 +31,14 @@ type RelayMetrics struct {
 	WSWriteDuration prometheus.Histogram
 }
 
-// NewRelayMetrics creates and registers Relay metrics with the given registry.
-func NewRelayMetrics(reg prometheus.Registerer) *RelayMetrics {
-	m := &RelayMetrics{
+// newRelayMetrics creates and registers Relay metrics with reg.
+// Returns nil if reg is nil so callers can treat a disabled registry as
+// "no metrics collected" via a simple nil check at each instrument site.
+func newRelayMetrics(reg prometheus.Registerer) *relayMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &relayMetrics{
 		ConnectionsCurrent: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "mocrelay_connections_current",
 			Help: "Current number of WebSocket connections",
@@ -88,8 +93,8 @@ func NewRelayMetrics(reg prometheus.Registerer) *RelayMetrics {
 	return m
 }
 
-// RouterMetrics holds Prometheus metrics for Router.
-type RouterMetrics struct {
+// routerMetrics holds Prometheus metrics for Router.
+type routerMetrics struct {
 	MessagesDropped prometheus.Counter
 
 	// SubscriptionsCurrent is the total number of active subscriptions
@@ -99,9 +104,13 @@ type RouterMetrics struct {
 	SubscriptionsCurrent prometheus.Gauge
 }
 
-// NewRouterMetrics creates and registers Router metrics with the given registry.
-func NewRouterMetrics(reg prometheus.Registerer) *RouterMetrics {
-	m := &RouterMetrics{
+// newRouterMetrics creates and registers Router metrics with reg.
+// Returns nil if reg is nil.
+func newRouterMetrics(reg prometheus.Registerer) *routerMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &routerMetrics{
 		MessagesDropped: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "mocrelay_router_messages_dropped_total",
 			Help: "Total number of messages dropped due to full send channel",
@@ -120,25 +129,29 @@ func NewRouterMetrics(reg prometheus.Registerer) *RouterMetrics {
 	return m
 }
 
-// AuthMetrics holds Prometheus metrics for AuthMiddleware.
+// authMetrics holds Prometheus metrics for AuthMiddleware.
 //
-// AuthMetrics is injected into the request context by [Relay] (via
-// [RelayOptions.AuthMetrics]); the auth middleware reads it via
-// [AuthMetricsFromContext] and no-ops on nil. Middleware code never holds a
-// reference directly, mirroring the [RejectionMetrics] / Logger pattern.
+// authMetrics is injected into the request context by [Relay] (constructed
+// from [RelayOptions.Registerer]); the auth middleware reads it via
+// [authMetricsFromContext] and no-ops on nil. Middleware code never holds a
+// reference directly, mirroring the [rejectionMetrics] / Logger pattern.
 //
 // Rejection metrics are not part of this struct. They are unified across all
-// middleware under [RejectionMetrics] and are wired automatically via
+// middleware under [rejectionMetrics] and are wired automatically via
 // [logRejection] — Auth contributes to the shared counter with label
 // middleware="auth".
-type AuthMetrics struct {
+type authMetrics struct {
 	AuthTotal                       *prometheus.CounterVec
 	AuthenticatedConnectionsCurrent prometheus.Gauge
 }
 
-// NewAuthMetrics creates and registers AuthMiddleware metrics with the given registry.
-func NewAuthMetrics(reg prometheus.Registerer) *AuthMetrics {
-	m := &AuthMetrics{
+// newAuthMetrics creates and registers AuthMiddleware metrics with reg.
+// Returns nil if reg is nil.
+func newAuthMetrics(reg prometheus.Registerer) *authMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &authMetrics{
 		AuthTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "mocrelay_auth_total",
 			Help: "Total number of authentication attempts",
@@ -159,24 +172,24 @@ func NewAuthMetrics(reg prometheus.Registerer) *AuthMetrics {
 
 type authMetricsKey struct{}
 
-// ContextWithAuthMetrics returns a new context carrying the given auth
+// contextWithAuthMetrics returns a new context carrying the given auth
 // metrics. [Relay] installs this at connection start so the auth middleware
 // downstream can record attempts and authenticated connections via
-// [AuthMetricsFromContext] without holding a direct reference.
-func ContextWithAuthMetrics(ctx context.Context, m *AuthMetrics) context.Context {
+// [authMetricsFromContext] without holding a direct reference.
+func contextWithAuthMetrics(ctx context.Context, m *authMetrics) context.Context {
 	return context.WithValue(ctx, authMetricsKey{}, m)
 }
 
-// AuthMetricsFromContext returns the auth metrics from the context, or nil
+// authMetricsFromContext returns the auth metrics from the context, or nil
 // if none was set. Callers must be nil-safe.
-func AuthMetricsFromContext(ctx context.Context) *AuthMetrics {
-	if m, ok := ctx.Value(authMetricsKey{}).(*AuthMetrics); ok {
+func authMetricsFromContext(ctx context.Context) *authMetrics {
+	if m, ok := ctx.Value(authMetricsKey{}).(*authMetrics); ok {
 		return m
 	}
 	return nil
 }
 
-// RejectionMetrics holds the unified rejection counter shared across every
+// rejectionMetrics holds the unified rejection counter shared across every
 // middleware in mocrelay. Each middleware reports its rejections through
 // [logRejection], which increments this counter with labels
 // {middleware, reason} — the same pair that appears in the structured log
@@ -185,19 +198,22 @@ func AuthMetricsFromContext(ctx context.Context) *AuthMetrics {
 // The (middleware, reason) pair is a functional relationship (each middleware
 // emits a fixed, small enum of reasons), so the label set is bounded and
 // does not form a cardinality cross-product — analogous to the (kind, type)
-// two-axis label on [RelayMetrics.EventsReceived].
+// two-axis label on [relayMetrics.EventsReceived].
 //
-// RejectionMetrics is injected into the request context by [Relay] (via
-// [RelayOptions.RejectionMetrics]); middleware code never holds a reference
-// and never needs a nil check — [logRejection] handles both.
-type RejectionMetrics struct {
+// rejectionMetrics is injected into the request context by [Relay]
+// (constructed from [RelayOptions.Registerer]); middleware code never holds
+// a reference and never needs a nil check — [logRejection] handles both.
+type rejectionMetrics struct {
 	Total *prometheus.CounterVec
 }
 
-// NewRejectionMetrics creates and registers the unified rejection counter
-// with the given registry.
-func NewRejectionMetrics(reg prometheus.Registerer) *RejectionMetrics {
-	m := &RejectionMetrics{
+// newRejectionMetrics creates and registers the unified rejection counter
+// with reg. Returns nil if reg is nil.
+func newRejectionMetrics(reg prometheus.Registerer) *rejectionMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &rejectionMetrics{
 		Total: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "mocrelay_rejections_total",
 			Help: "Total number of client messages rejected by middleware, " +
@@ -214,26 +230,26 @@ func NewRejectionMetrics(reg prometheus.Registerer) *RejectionMetrics {
 
 type rejectionMetricsKey struct{}
 
-// ContextWithRejectionMetrics returns a new context carrying the given
+// contextWithRejectionMetrics returns a new context carrying the given
 // rejection metrics. [Relay] installs this at connection start so middleware
 // downstream can report rejections via [logRejection] without holding a
 // direct reference.
-func ContextWithRejectionMetrics(ctx context.Context, m *RejectionMetrics) context.Context {
+func contextWithRejectionMetrics(ctx context.Context, m *rejectionMetrics) context.Context {
 	return context.WithValue(ctx, rejectionMetricsKey{}, m)
 }
 
-// RejectionMetricsFromContext returns the rejection metrics from the context,
-// or nil if none was set. Callers (in practice only [logRejection]) must be
-// nil-safe.
-func RejectionMetricsFromContext(ctx context.Context) *RejectionMetrics {
-	if m, ok := ctx.Value(rejectionMetricsKey{}).(*RejectionMetrics); ok {
+// rejectionMetricsFromContext returns the rejection metrics from the
+// context, or nil if none was set. Callers (in practice only
+// [logRejection]) must be nil-safe.
+func rejectionMetricsFromContext(ctx context.Context) *rejectionMetrics {
+	if m, ok := ctx.Value(rejectionMetricsKey{}).(*rejectionMetrics); ok {
 		return m
 	}
 	return nil
 }
 
-// StorageMetrics holds Prometheus metrics for Storage.
-type StorageMetrics struct {
+// storageMetrics holds Prometheus metrics for Storage.
+type storageMetrics struct {
 	EventsStored  *prometheus.CounterVec
 	StoreDuration prometheus.Histogram
 	QueryDuration prometheus.Histogram
@@ -248,9 +264,13 @@ type StorageMetrics struct {
 	QueryErrors prometheus.Counter
 }
 
-// NewStorageMetrics creates and registers Storage metrics with the given registry.
-func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
-	m := &StorageMetrics{
+// newStorageMetrics creates and registers Storage metrics with reg.
+// Returns nil if reg is nil.
+func newStorageMetrics(reg prometheus.Registerer) *storageMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &storageMetrics{
 		EventsStored: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "mocrelay_events_stored_total",
 			Help: "Total number of event store attempts",
@@ -286,7 +306,7 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 	return m
 }
 
-// CompositeStorageMetrics holds Prometheus metrics for [CompositeStorage].
+// compositeStorageMetrics holds Prometheus metrics for [CompositeStorage].
 //
 // These instrument the two places where [CompositeStorage] would otherwise
 // silently swallow backend failures:
@@ -305,7 +325,7 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 // size, batch statistics) lives on the caller's [bleve.Index] and should
 // be collected directly from idx.StatsMap() by the caller — see the
 // "Caller-owned *pebble.DB and bleve.Index" section in CLAUDE.md.
-type CompositeStorageMetrics struct {
+type compositeStorageMetrics struct {
 	// SearchTotal counts Query calls that hit the search backend (Search
 	// filter non-empty and a search index is configured). Paired with
 	// SearchErrors to derive a search error rate.
@@ -328,10 +348,13 @@ type CompositeStorageMetrics struct {
 	IndexErrors prometheus.Counter
 }
 
-// NewCompositeStorageMetrics creates and registers CompositeStorage
-// metrics with the given registry.
-func NewCompositeStorageMetrics(reg prometheus.Registerer) *CompositeStorageMetrics {
-	m := &CompositeStorageMetrics{
+// newCompositeStorageMetrics creates and registers CompositeStorage
+// metrics with reg. Returns nil if reg is nil.
+func newCompositeStorageMetrics(reg prometheus.Registerer) *compositeStorageMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &compositeStorageMetrics{
 		SearchTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "mocrelay_search_total",
 			Help: "Total number of Query calls that hit the search backend " +
@@ -367,13 +390,13 @@ func NewCompositeStorageMetrics(reg prometheus.Registerer) *CompositeStorageMetr
 	return m
 }
 
-// MergeHandlerMetrics holds Prometheus metrics for [NewMergeHandler].
+// mergeHandlerMetrics holds Prometheus metrics for [NewMergeHandler].
 //
 // These surface the USE-Saturation and USE-Errors axes of the merge
 // handler: how often downstream children are retired or stall on control
 // broadcasts, and how many EVENT messages are dropped (on the way in,
 // or during dedup/sort/limit enforcement on the way out).
-type MergeHandlerMetrics struct {
+type mergeHandlerMetrics struct {
 	// LostChildrenTotal counts child handlers retired mid-flight. A lost
 	// child contributes a synthesized accepted=false OK to its pending
 	// responses (see MergeHandlerOKLostHandlerMessage) and prompts the
@@ -400,10 +423,13 @@ type MergeHandlerMetrics struct {
 	EventDrops *prometheus.CounterVec
 }
 
-// NewMergeHandlerMetrics creates and registers merge handler metrics with
-// the given registry.
-func NewMergeHandlerMetrics(reg prometheus.Registerer) *MergeHandlerMetrics {
-	m := &MergeHandlerMetrics{
+// newMergeHandlerMetrics creates and registers merge handler metrics with
+// reg. Returns nil if reg is nil.
+func newMergeHandlerMetrics(reg prometheus.Registerer) *mergeHandlerMetrics {
+	if reg == nil {
+		return nil
+	}
+	m := &mergeHandlerMetrics{
 		LostChildrenTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "mocrelay_merge_lost_children_total",
 			Help: "Total number of merge-handler child handlers retired " +

--- a/metrics_storage.go
+++ b/metrics_storage.go
@@ -6,24 +6,40 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-// MetricsStorage wraps a Storage and collects Prometheus metrics.
+// MetricsStorage wraps a Storage and collects Prometheus metrics for each
+// Store / Query call (mocrelay_events_stored_total, mocrelay_store_duration_seconds,
+// mocrelay_query_duration_seconds, mocrelay_store_errors_total,
+// mocrelay_query_errors_total).
+//
+// Because mocrelay's Storage interface has multiple implementations
+// (InMemory / Pebble / Composite), MetricsStorage is a decorator rather than
+// an Options-style constructor: wrap whatever Storage you want to measure.
 type MetricsStorage struct {
 	storage Storage
-	metrics *StorageMetrics
+	metrics *storageMetrics
 }
 
-// NewMetricsStorage creates a new MetricsStorage that wraps the given storage.
-func NewMetricsStorage(storage Storage, metrics *StorageMetrics) *MetricsStorage {
+// NewMetricsStorage creates a MetricsStorage wrapping storage. Metrics are
+// registered against reg; if reg is nil, all metric calls no-op and the
+// decorator is effectively a pass-through (no registration happens and no
+// Prometheus collectors are created).
+func NewMetricsStorage(storage Storage, reg prometheus.Registerer) *MetricsStorage {
 	return &MetricsStorage{
 		storage: storage,
-		metrics: metrics,
+		metrics: newStorageMetrics(reg),
 	}
 }
 
 // Store implements Storage.Store with metrics collection.
 func (s *MetricsStorage) Store(ctx context.Context, event *Event) (bool, error) {
+	if s.metrics == nil {
+		return s.storage.Store(ctx, event)
+	}
+
 	start := time.Now()
 	stored, err := s.storage.Store(ctx, event)
 	duration := time.Since(start)
@@ -42,6 +58,10 @@ func (s *MetricsStorage) Store(ctx context.Context, event *Event) (bool, error) 
 
 // Query implements Storage.Query with metrics collection.
 func (s *MetricsStorage) Query(ctx context.Context, filters []*ReqFilter) (iter.Seq[*Event], func() error, func() error) {
+	if s.metrics == nil {
+		return s.storage.Query(ctx, filters)
+	}
+
 	start := time.Now()
 	events, errFn, closeFn := s.storage.Query(ctx, filters)
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -38,9 +38,8 @@ func (s *errStorage) Query(ctx context.Context, filters []*ReqFilter) (iter.Seq[
 // and asserts that each rejection lands on its labeled WSParseErrors counter.
 func TestMetrics_RelayWSParseErrors(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewRelayMetrics(reg)
 
-	relay := NewRelay(NewNopHandler(), &RelayOptions{Metrics: metrics})
+	relay := NewRelay(NewNopHandler(), &RelayOptions{Registerer: reg})
 	server := httptest.NewServer(relay)
 	defer server.Close()
 
@@ -74,7 +73,7 @@ func TestMetrics_RelayWSParseErrors(t *testing.T) {
 	}
 
 	got := func(reason string) float64 {
-		return testutil.ToFloat64(metrics.WSParseErrors.WithLabelValues(reason))
+		return testutil.ToFloat64(relay.metrics.WSParseErrors.WithLabelValues(reason))
 	}
 	assert.Equal(t, float64(1), got("binary_message"))
 	assert.Equal(t, float64(1), got("invalid_utf8"))
@@ -88,11 +87,10 @@ func TestMetrics_RelayWSParseErrors(t *testing.T) {
 // CLOSE" case.
 func TestMetrics_Router_SubscriptionsCurrent(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewRouterMetrics(reg)
-	router := NewRouter(&RouterOptions{Metrics: metrics})
+	router := NewRouter(&RouterOptions{Registerer: reg})
 
 	gauge := func() float64 {
-		return testutil.ToFloat64(metrics.SubscriptionsCurrent)
+		return testutil.ToFloat64(router.metrics.SubscriptionsCurrent)
 	}
 
 	sendA := make(chan *ServerMsg, 1)
@@ -131,27 +129,25 @@ func TestMetrics_Router_SubscriptionsCurrent(t *testing.T) {
 // failing Store and stays at zero otherwise.
 func TestMetrics_MetricsStorage_StoreErrors(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewStorageMetrics(reg)
 
 	underlying := &errStorage{storeErr: errors.New("disk gone")}
-	ms := NewMetricsStorage(underlying, metrics)
+	ms := NewMetricsStorage(underlying, reg)
 
 	_, err := ms.Store(context.Background(), makeEvent("e1", "pubkey01", 1, 100))
 	assert.Error(t, err)
 	_, err = ms.Store(context.Background(), makeEvent("e2", "pubkey01", 1, 200))
 	assert.Error(t, err)
 
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.StoreErrors))
+	assert.Equal(t, float64(2), testutil.ToFloat64(ms.metrics.StoreErrors))
 }
 
 // TestMetrics_MetricsStorage_QueryErrors asserts QueryErrors increments exactly
 // once per failed Query, even if the caller invokes errFn multiple times.
 func TestMetrics_MetricsStorage_QueryErrors(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewStorageMetrics(reg)
 
 	underlying := &errStorage{queryErr: errors.New("corrupt index")}
-	ms := NewMetricsStorage(underlying, metrics)
+	ms := NewMetricsStorage(underlying, reg)
 
 	_, errFn, closeFn := ms.Query(context.Background(), []*ReqFilter{{}})
 	// Iteration yields nothing; errFn reports the error.
@@ -165,7 +161,7 @@ func TestMetrics_MetricsStorage_QueryErrors(t *testing.T) {
 	assert.Error(t, errFn2())
 	assert.NoError(t, closeFn2())
 
-	assert.Equal(t, float64(2), testutil.ToFloat64(metrics.QueryErrors))
+	assert.Equal(t, float64(2), testutil.ToFloat64(ms.metrics.QueryErrors))
 }
 
 // TestMetrics_MetricsStorage_NoErrorsOnSuccess asserts the counters stay at
@@ -173,9 +169,8 @@ func TestMetrics_MetricsStorage_QueryErrors(t *testing.T) {
 // branch.
 func TestMetrics_MetricsStorage_NoErrorsOnSuccess(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewStorageMetrics(reg)
 
-	ms := NewMetricsStorage(NewInMemoryStorage(), metrics)
+	ms := NewMetricsStorage(NewInMemoryStorage(), reg)
 
 	_, err := ms.Store(context.Background(), makeEvent("e1", "pubkey01", 1, 100))
 	assert.NoError(t, err)
@@ -190,8 +185,8 @@ func TestMetrics_MetricsStorage_NoErrorsOnSuccess(t *testing.T) {
 	assert.NoError(t, errFn())
 	assert.NoError(t, closeFn())
 
-	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.StoreErrors))
-	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.QueryErrors))
+	assert.Equal(t, float64(0), testutil.ToFloat64(ms.metrics.StoreErrors))
+	assert.Equal(t, float64(0), testutil.ToFloat64(ms.metrics.QueryErrors))
 }
 
 // TestMetrics_MergeHandler_LostChildAndBroadcastTimeout asserts that a stuck
@@ -201,7 +196,7 @@ func TestMetrics_MetricsStorage_NoErrorsOnSuccess(t *testing.T) {
 func TestMetrics_MergeHandler_LostChildAndBroadcastTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		metrics := NewMergeHandlerMetrics(reg)
+		metrics := newMergeHandlerMetrics(reg)
 
 		stuck := &stuckHandler{}
 		h := &mergeHandler{
@@ -245,7 +240,6 @@ func TestMetrics_MergeHandler_LostChildAndBroadcastTimeout(t *testing.T) {
 func TestMetrics_MergeHandler_EventDrops_Duplicate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		metrics := NewMergeHandlerMetrics(reg)
 
 		storage1 := NewInMemoryStorage()
 		storage2 := NewInMemoryStorage()
@@ -256,8 +250,9 @@ func TestMetrics_MergeHandler_EventDrops_Duplicate(t *testing.T) {
 
 		mh := NewMergeHandler(
 			[]Handler{NewStorageHandler(storage1, nil), NewStorageHandler(storage2, nil)},
-			&MergeHandlerOptions{Metrics: metrics},
-		)
+			&MergeHandlerOptions{Registerer: reg},
+		).(*mergeHandler)
+		metrics := mh.metrics
 
 		ctx2, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -281,7 +276,7 @@ func TestMetrics_MergeHandler_EventDrops_Duplicate(t *testing.T) {
 func TestMetrics_MergeHandler_EventDrops_RecvBufFull(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		metrics := NewMergeHandlerMetrics(reg)
+		metrics := newMergeHandlerMetrics(reg)
 
 		stuck := &stuckHandler{}
 		h := &mergeHandler{

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -13,10 +13,10 @@ import (
 // [NewAuthMiddlewareBase]. All fields are optional; the zero value gives
 // sensible defaults.
 //
-// Metrics are not part of this struct. [AuthMetrics] is injected via the
-// request context by [Relay] (see [RelayOptions.AuthMetrics]) and read by
-// the auth middleware via [AuthMetricsFromContext], mirroring the
-// [RejectionMetrics] / Logger pattern.
+// Metrics are not part of this struct. Auth metrics are constructed by
+// [Relay] from [RelayOptions.Registerer] and injected into the request
+// context; the auth middleware reads them internally without holding a
+// direct reference, mirroring the rejection counter / Logger pattern.
 type AuthMiddlewareOptions struct {
 	// CreatedAtTolerance is the maximum age of auth events.
 	// Default: 10 minutes (as recommended by NIP-42)
@@ -77,7 +77,7 @@ func (m *authMiddleware) OnStart(ctx context.Context) (context.Context, *ServerM
 }
 
 func (m *authMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
-	if metrics := AuthMetricsFromContext(ctx); metrics != nil {
+	if metrics := authMetricsFromContext(ctx); metrics != nil {
 		state := ctx.Value(authCtxKey{}).(*authState)
 		state.mu.RLock()
 		authenticated := state.authenticated
@@ -141,7 +141,7 @@ func (m *authMiddleware) HandleServerMsg(
 }
 
 func (m *authMiddleware) handleAuth(ctx context.Context, state *authState, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
-	metrics := AuthMetricsFromContext(ctx)
+	metrics := authMetricsFromContext(ctx)
 
 	if msg.Event == nil {
 		logRejection(ctx, "auth", "missing_auth_event")

--- a/relay.go
+++ b/relay.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/coder/websocket"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Relay wraps a Handler to serve it over HTTP/WebSocket.
@@ -25,9 +26,9 @@ type Relay struct {
 	pingInterval     time.Duration
 	pingTimeout      time.Duration
 	info             *RelayInfo
-	metrics          *RelayMetrics
-	rejectionMetrics *RejectionMetrics
-	authMetrics      *AuthMetrics
+	metrics          *relayMetrics
+	rejectionMetrics *rejectionMetrics
+	authMetrics      *authMetrics
 	connIDFunc       func() string
 
 	mu      sync.Mutex
@@ -64,24 +65,31 @@ type RelayOptions struct {
 	// Accept: application/nostr+json header.
 	Info *RelayInfo
 
-	// Metrics is the Prometheus metrics collector.
-	// If set, the relay will collect connection and message metrics.
-	Metrics *RelayMetrics
-
-	// RejectionMetrics is the unified rejection counter shared across every
-	// middleware. If set, the relay installs it into the request context so
-	// that logRejection (called from every middleware drop) auto-increments
-	// the counter alongside its structured log entry. If nil, rejections are
-	// only logged — no counter is incremented.
-	RejectionMetrics *RejectionMetrics
-
-	// AuthMetrics is the Prometheus metrics collector for the auth
-	// middleware (NIP-42). If set, the relay installs it into the request
-	// context so that NewAuthMiddlewareBase downstream records attempts
-	// and authenticated connections via AuthMetricsFromContext. If nil,
-	// auth events are not measured (rejections are still counted via
-	// RejectionMetrics with middleware="auth" where applicable).
-	AuthMetrics *AuthMetrics
+	// Registerer is the Prometheus registry that mocrelay's internal
+	// metrics are registered with. Setting this single field turns on every
+	// metric mocrelay exports from the Relay's own scope:
+	//
+	//   - Connection / message / event counters on the Relay itself
+	//     (mocrelay_connections_*, mocrelay_messages_*, mocrelay_events_received_*,
+	//     mocrelay_ws_parse_errors_*, mocrelay_ws_write_errors_*,
+	//     mocrelay_ws_write_duration_seconds).
+	//   - The unified rejection counter
+	//     (mocrelay_rejections_total{middleware, reason}), automatically
+	//     installed into the request context so that every middleware's
+	//     logRejection call increments it.
+	//   - Auth middleware counters (mocrelay_auth_*,
+	//     mocrelay_auth_authenticated_connections_current), also installed
+	//     into the request context and read by the auth middleware.
+	//
+	// Metrics owned by types that compose *into* Relay (Router, Storage,
+	// CompositeStorage, MergeHandler, MetricsStorage) are registered from
+	// their own constructors; pass the same Registerer to each of those
+	// Options structs (typically prometheus.DefaultRegisterer) to collect
+	// everything under one registry.
+	//
+	// If nil, no metrics are registered from this Relay and all internal
+	// instrumentation no-ops.
+	Registerer prometheus.Registerer
 
 	// ConnIDFunc generates a unique connection ID string.
 	// If nil, a default monotonic counter ("1", "2", ...) is used.
@@ -122,9 +130,9 @@ func NewRelay(handler Handler, opts *RelayOptions) *Relay {
 		pingInterval:     pingInterval,
 		pingTimeout:      pingTimeout,
 		info:             opts.Info,
-		metrics:          opts.Metrics,
-		rejectionMetrics: opts.RejectionMetrics,
-		authMetrics:      opts.AuthMetrics,
+		metrics:          newRelayMetrics(opts.Registerer),
+		rejectionMetrics: newRejectionMetrics(opts.Registerer),
+		authMetrics:      newAuthMetrics(opts.Registerer),
 		connIDFunc:       opts.ConnIDFunc,
 	}
 }
@@ -238,10 +246,10 @@ func (r *Relay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	logger := r.logger.With("conn_id", connID)
 	ctx = ContextWithLogger(ctx, logger)
 	if r.rejectionMetrics != nil {
-		ctx = ContextWithRejectionMetrics(ctx, r.rejectionMetrics)
+		ctx = contextWithRejectionMetrics(ctx, r.rejectionMetrics)
 	}
 	if r.authMetrics != nil {
-		ctx = ContextWithAuthMetrics(ctx, r.authMetrics)
+		ctx = contextWithAuthMetrics(ctx, r.authMetrics)
 	}
 
 	// Metrics: connection tracking

--- a/router.go
+++ b/router.go
@@ -2,6 +2,8 @@ package mocrelay
 
 import (
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Router manages client connections and subscriptions.
@@ -15,7 +17,7 @@ type Router struct {
 	// connections maps connection ID to connection info.
 	connections map[string]*routerConnection
 
-	metrics *RouterMetrics
+	metrics *routerMetrics
 }
 
 // routerConnection represents a single client connection.
@@ -30,9 +32,11 @@ type routerConnection struct {
 // RouterOptions configures Router behavior.
 // All fields are optional; the zero value gives sensible defaults.
 type RouterOptions struct {
-	// Metrics is the Prometheus metrics collector for Router.
-	// If nil, no metrics are collected.
-	Metrics *RouterMetrics
+	// Registerer is the Prometheus registry that Router's internal metrics
+	// are registered with (mocrelay_router_messages_dropped_total and
+	// mocrelay_router_subscriptions_current). If nil, no metrics are
+	// collected.
+	Registerer prometheus.Registerer
 }
 
 // NewRouter creates a new Router.
@@ -43,7 +47,7 @@ func NewRouter(opts *RouterOptions) *Router {
 	}
 	return &Router{
 		connections: make(map[string]*routerConnection),
-		metrics:     opts.Metrics,
+		metrics:     newRouterMetrics(opts.Registerer),
 	}
 }
 


### PR DESCRIPTION
## Summary

Replace the per-component `*Metrics` / `RejectionMetrics` / `AuthMetrics` fields on every `*Options` struct with a single `Registerer prometheus.Registerer` field. Setting it registers every metric the component owns; `nil` disables instrumentation end-to-end.

- Affected Options: `RelayOptions` (Relay + rejection + auth, ctx-injected), `RouterOptions`, `CompositeStorageOptions`, `MergeHandlerOptions`
- Decorator: `NewMetricsStorage(storage, reg)` — `reg == nil` is a pass-through
- All `*Metrics` structs, their constructors, and the ctx helpers (`ContextWith{Rejection,Auth}Metrics`, `{Rejection,Auth}MetricsFromContext`) are now unexported — the public surface is just the `Registerer` field on each Options

## Motivation

Callers in moctane-mocrelay threaded the same `reg` through six `New*Metrics` constructors to wire the full pipeline:

```go
// Before
reg := prometheus.DefaultRegisterer
relayOpts := &mocrelay.RelayOptions{
    Metrics:          mocrelay.NewRelayMetrics(reg),
    RejectionMetrics: mocrelay.NewRejectionMetrics(reg),
    AuthMetrics:      mocrelay.NewAuthMetrics(reg),
}
router := mocrelay.NewRouter(&mocrelay.RouterOptions{
    Metrics: mocrelay.NewRouterMetrics(reg),
})
composite := mocrelay.NewCompositeStorage(pebble, bleve, &mocrelay.CompositeStorageOptions{
    Metrics: mocrelay.NewCompositeStorageMetrics(reg),
})
storage := mocrelay.NewMetricsStorage(composite, mocrelay.NewStorageMetrics(reg))
```

The Registerer is itself the consent ("I want these metrics"); making each Options take it directly collapses the boilerplate:

```go
// After
relayOpts := &mocrelay.RelayOptions{Registerer: reg}
router := mocrelay.NewRouter(&mocrelay.RouterOptions{Registerer: reg})
composite := mocrelay.NewCompositeStorage(pebble, bleve, &mocrelay.CompositeStorageOptions{Registerer: reg})
storage := mocrelay.NewMetricsStorage(composite, reg)
```

Six constructor calls → one field per Options. The `*Metrics` public type surface existed only to be registered once and handed back — it's now gone.

## Design discussion (captured for posterity)

A few alternatives were weighed before settling on this shape:

1. **Single `RelayOptions.Registerer` covering the whole pipeline.** Structurally impossible — `Router` / `CompositeStorage` / `MergeHandler` are constructed *before* the `Relay` and handed in as a `Handler`. Each owning type has to take its own `Registerer`. Passing the same `reg` everywhere is still one line per Options, not one line total.

2. **Keep `*Metrics` public alongside the new `Registerer` field.** Rejected: an `opts.Registerer != nil && opts.Metrics != nil` state would need a priority rule, the public surface would grow rather than shrink, and the subregistry use case (main motivation for keeping `*Metrics` public) is already served by `prometheus.WrapRegistererWithPrefix(reg, ...)`.

3. **Lazy / `sync.Once` registration triggered by first `Inc`.** Considered to avoid "use-less `AuthenticatedConnectionsCurrent` gauge at value 0" noise in `/metrics` when auth isn't wired. Rejected: Prometheus operational convention is to have metrics present from startup so dashboards and `absent()` alerts are stable. Most of the affected series are `*Vec` anyway, which are already lazy at the label-value level — only a handful of plain Gauges / Counters ever appear at 0, which is expected shape.

## Test plan

- [x] `go build ./...` green (library + `cmd/examples/kitchen-sink`)
- [x] `go vet ./...` green
- [x] `go test ./...` green (full suite including `metrics_test.go`, `composite_storage_test.go`, `logger_test.go` — all `*_test.go` files are in `package mocrelay` so they access the now-unexported fields via internal test package)
- [ ] moctane-mocrelay bump: follow-up PR to switch from `NewRelayMetrics(reg)` / etc. to `Registerer: reg` on every Options struct.

## Docs

`CLAUDE.md` Metrics section rewritten:
- Section renamed "Nil-safe injection" → "Registerer injection"
- Coverage-by-layer table now lists Prometheus series names (authoritative now that Go fields are unexported)
- Go-field↔series mapping table collapsed into a prose note pointing to `metrics.go`
- Constructor API rule + `MetricsStorage` exception updated to match the new shape

🌸 Generated with [Claude Code](https://claude.com/claude-code)