### PR TITLE
fix(storage_handler): honor QueryTimeout at the send<-msg boundary

### DIFF
--- a/storage_handler.go
+++ b/storage_handler.go
@@ -299,12 +299,17 @@ func (h *storageHandler) handleReq(
 		eventsSent++
 	}
 
+	// Capture the query result once. Storage.Query's errFn contract does
+	// not promise idempotence across calls, so we must not re-invoke it
+	// after using its return value in the abort-decision predicate below.
+	queryErr := errFn()
+
 	// Terminal-message decision. A queryCtx failure while outer ctx is
 	// still alive means QueryTimeout fired → send CLOSED. Storage impls
 	// that respect ctx may also surface context.DeadlineExceeded via
 	// errFn; treat that the same as a queryCtx-driven abort.
 	if (queryCtx.Err() != nil && ctx.Err() == nil) ||
-		errors.Is(errFn(), context.DeadlineExceeded) {
+		errors.Is(queryErr, context.DeadlineExceeded) {
 		// Emit CLOSED on the outer ctx. If outer ctx is cancelled the
 		// send will just fail and we'll return its err — the connection
 		// is going away anyway.
@@ -315,13 +320,19 @@ func (h *storageHandler) handleReq(
 		return err
 	}
 
-	if err := errFn(); err != nil {
-		LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err, "subscription_id", msg.SubscriptionID)
+	if queryErr != nil {
+		LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", queryErr, "subscription_id", msg.SubscriptionID)
 		// Even on query error we still try to send EOSE so the client
 		// isn't left hanging — matches prior behavior.
 	}
 
-	// Send EOSE to signal end of stored events.
+	// Send EOSE to signal end of stored events. The slow-query
+	// `completed` flag below is `err == nil`, i.e. true only when the
+	// EOSE actually made it onto send. Treat it as "the relay finished
+	// the subscription cleanly" rather than "the client received it" —
+	// the latter can't be observed from this side. An EOSE that fails
+	// because the outer ctx was cancelled mid-send is logged with
+	// completed=false, matching the abort path's semantics.
 	s := time.Now()
 	err := sendServerMsg(ctx, send, NewServerEOSEMsg(msg.SubscriptionID))
 	sendWait += time.Since(s)
@@ -362,15 +373,19 @@ func (h *storageHandler) handleCount(
 		count++
 	}
 
+	// Capture the query result once; see handleReq for why errFn must not
+	// be re-invoked.
+	queryErr := errFn()
+
 	if (queryCtx.Err() != nil && ctx.Err() == nil) ||
-		errors.Is(errFn(), context.DeadlineExceeded) {
+		errors.Is(queryErr, context.DeadlineExceeded) {
 		err := sendServerMsg(ctx, send, NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
 		h.maybeLogSlowCount(ctx, msg, start, count)
 		return err
 	}
 
-	if err := errFn(); err != nil {
-		LoggerFromContext(ctx).WarnContext(ctx, "count query error", "error", err, "subscription_id", msg.SubscriptionID)
+	if queryErr != nil {
+		LoggerFromContext(ctx).WarnContext(ctx, "count query error", "error", queryErr, "subscription_id", msg.SubscriptionID)
 		sendErr := sendServerMsg(ctx, send, NewServerCountMsg(msg.SubscriptionID, 0, nil))
 		h.maybeLogSlowCount(ctx, msg, start, count)
 		return sendErr

--- a/storage_handler.go
+++ b/storage_handler.go
@@ -3,7 +3,6 @@ package mocrelay
 import (
 	"context"
 	"errors"
-	"iter"
 	"time"
 )
 
@@ -87,13 +86,21 @@ func NewStorageHandler(storage Storage, opts *StorageHandlerOptions) Handler {
 			queryTimeout = opts.QueryTimeout
 		}
 	}
-	return NewSimpleHandler(&storageHandler{
+	return &storageHandler{
 		storage:            storage,
 		slowQueryThreshold: threshold,
 		queryTimeout:       queryTimeout,
-	})
+	}
 }
 
+// storageHandler implements [Handler] directly rather than routing through
+// [SimpleHandlerBase]. The reason is QueryTimeout: a per-REQ abort deadline
+// must be visible at the send<-msg boundary as well as during scan. The
+// SimpleHandlerBase path routes yields through a per-connection ctx that
+// is not scoped to the in-flight REQ, so a blocked send (stalled receiver)
+// survives past the timeout indefinitely — the "live but slow client"
+// stall observed on salmon. Owning ServeNostr directly lets us attach the
+// timeout ctx to the exact send sites that can stall.
 type storageHandler struct {
 	storage Storage
 	// slowQueryThreshold is the effective threshold for slow-query logging.
@@ -104,180 +111,224 @@ type storageHandler struct {
 	queryTimeout time.Duration
 }
 
-func (h *storageHandler) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
-	return ctx, nil, nil
-}
-
-func (h *storageHandler) OnEnd(ctx context.Context) (*ServerMsg, error) {
-	return nil, nil
-}
-
-func (h *storageHandler) HandleMsg(ctx context.Context, msg *ClientMsg) (iter.Seq[*ServerMsg], error) {
-	switch msg.Type {
-	case MsgTypeEvent:
-		return h.handleEvent(ctx, msg)
-	case MsgTypeReq:
-		return h.handleReq(ctx, msg)
-	case MsgTypeClose:
-		// StorageHandler doesn't manage subscriptions, so CLOSE is a no-op
-		return nil, nil
-	case MsgTypeCount:
-		return h.handleCount(ctx, msg)
-	default:
-		return nil, nil
+func (h *storageHandler) ServeNostr(
+	ctx context.Context,
+	send chan<- *ServerMsg,
+	recv <-chan *ClientMsg,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-recv:
+			if !ok {
+				return nil
+			}
+			switch msg.Type {
+			case MsgTypeEvent:
+				if err := h.handleEvent(ctx, send, msg); err != nil {
+					return err
+				}
+			case MsgTypeReq:
+				if err := h.handleReq(ctx, send, msg); err != nil {
+					return err
+				}
+			case MsgTypeCount:
+				if err := h.handleCount(ctx, send, msg); err != nil {
+					return err
+				}
+			case MsgTypeClose:
+				// StorageHandler doesn't manage subscriptions, so
+				// CLOSE is a no-op. Pair with RouterHandler via
+				// MergeHandler to route CLOSE to the router.
+			}
+		}
 	}
 }
 
-func (h *storageHandler) handleEvent(ctx context.Context, msg *ClientMsg) (iter.Seq[*ServerMsg], error) {
-	return func(yield func(*ServerMsg) bool) {
-		if msg.Event == nil {
-			yield(NewServerOKMsg("", false, "error: no event provided"))
-			return
-		}
+// sendServerMsg forwards m on send, returning ctx.Err() if ctx is
+// cancelled before the send completes.
+func sendServerMsg(ctx context.Context, send chan<- *ServerMsg, m *ServerMsg) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case send <- m:
+		return nil
+	}
+}
 
-		stored, err := h.storage.Store(ctx, msg.Event)
+func (h *storageHandler) handleEvent(
+	ctx context.Context,
+	send chan<- *ServerMsg,
+	msg *ClientMsg,
+) error {
+	if msg.Event == nil {
+		return sendServerMsg(ctx, send, NewServerOKMsg("", false, "error: no event provided"))
+	}
+	stored, err := h.storage.Store(ctx, msg.Event)
+	if err != nil {
+		LoggerFromContext(ctx).ErrorContext(ctx, "store error", "error", err, "event_id", msg.Event.ID)
+		return sendServerMsg(ctx, send, NewServerOKMsg(msg.Event.ID, false, "error: internal error"))
+	}
+	if stored {
+		return sendServerMsg(ctx, send, NewServerOKMsg(msg.Event.ID, true, ""))
+	}
+	// Not stored: could be duplicate, older replaceable, deleted, or ephemeral.
+	return sendServerMsg(ctx, send, NewServerOKMsg(msg.Event.ID, true, "duplicate: already have this event"))
+}
+
+func (h *storageHandler) handleReq(
+	ctx context.Context,
+	send chan<- *ServerMsg,
+	msg *ClientMsg,
+) error {
+	if msg.SubscriptionID == "" {
+		return nil
+	}
+
+	// start is taken before Query so the iterator-initialization cost
+	// (index seek, snapshot creation, etc.) counts toward total.
+	start := time.Now()
+
+	// queryCtx derives from the connection ctx and expires at QueryTimeout.
+	// It is the abort signal for BOTH scan and send<-msg below. Keeping
+	// the timeout scoped to this function means a stalled receiver can't
+	// outlive the deadline — the "live but slow client" regression.
+	queryCtx := ctx
+	if h.queryTimeout > 0 {
+		var cancel context.CancelFunc
+		queryCtx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+		defer cancel()
+	}
+
+	events, errFn, closeFn := h.storage.Query(queryCtx, msg.Filters)
+	defer closeFn()
+
+	// sendWait accumulates time spent blocked on send<-msg (send wait) as
+	// opposed to scan; they partition total (iter.Seq is pull-driven so a
+	// blocked send also pauses the iterator). Both are still reported
+	// separately because which side owns a stall determines the fix.
+	var sendWait time.Duration
+	eventsSent := 0
+
+	// trySendEvent forwards m on send, watching queryCtx (QueryTimeout)
+	// alongside the normal delivery path. Return values:
+	//   (true,  nil) → queryCtx fired; caller should break and emit CLOSED
+	//   (false, err) → outer ctx cancelled or other fatal; caller returns
+	//   (false, nil) → event delivered; caller continues
+	trySendEvent := func(m *ServerMsg) (aborted bool, err error) {
+		s := time.Now()
+		defer func() { sendWait += time.Since(s) }()
+		select {
+		case send <- m:
+			return false, nil
+		case <-queryCtx.Done():
+			// queryCtx fires for timeout *or* outer-ctx cancel (it is
+			// derived from ctx). Distinguish via ctx.Err.
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+			return true, nil
+		}
+	}
+
+	for event := range events {
+		// Fast path: timeout fired while scanning / waiting to send the
+		// previous event. Abort before emitting another one.
+		if queryCtx.Err() != nil {
+			break
+		}
+		aborted, err := trySendEvent(NewServerEventMsg(msg.SubscriptionID, event))
 		if err != nil {
-			LoggerFromContext(ctx).ErrorContext(ctx, "store error", "error", err, "event_id", msg.Event.ID)
-			yield(NewServerOKMsg(msg.Event.ID, false, "error: internal error"))
-			return
-		}
-
-		if stored {
-			yield(NewServerOKMsg(msg.Event.ID, true, ""))
-		} else {
-			// Not stored: could be duplicate, older replaceable, deleted, or ephemeral
-			yield(NewServerOKMsg(msg.Event.ID, true, "duplicate: already have this event"))
-		}
-	}, nil
-}
-
-func (h *storageHandler) handleReq(ctx context.Context, msg *ClientMsg) (iter.Seq[*ServerMsg], error) {
-	return func(yield func(*ServerMsg) bool) {
-		if msg.SubscriptionID == "" {
-			return
-		}
-
-		// start is taken before Query so the iterator-initialization cost
-		// (index seek, snapshot creation, etc.) counts toward total.
-		start := time.Now()
-
-		// Apply QueryTimeout by wrapping the context. Storage implementations
-		// that respect ctx will short-circuit; the iteration loop below polls
-		// ctx.Err so implementations that don't (e.g. Pebble) are stopped at
-		// the next event boundary.
-		if h.queryTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
-			defer cancel()
-		}
-
-		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
-		defer closeFn()
-
-		// Measure time spent inside yield (send wait) vs outside yield
-		// (scan). iter.Seq is pull-driven so yield blocking also pauses
-		// the storage iterator — the two are entangled. But the split
-		// is still operationally meaningful: a large sendWait relative
-		// to scan points at a stalled client; the reverse points at
-		// filter / index / data-volume costs.
-		var sendWait time.Duration
-		eventsSent := 0
-
-		// yieldTracked wraps yield so every emission contributes to
-		// sendWait, including the trailing EOSE / CLOSED — which matters
-		// when the stall is on the client side (the terminal message
-		// never arrives either).
-		yieldTracked := func(m *ServerMsg) bool {
-			s := time.Now()
-			ok := yield(m)
-			sendWait += time.Since(s)
-			return ok
-		}
-
-		for event := range events {
-			// Fast path first: timeout fired while scanning / waiting to
-			// send the previous event. Abort before emitting another one.
-			if ctx.Err() != nil {
-				yieldTracked(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
-				h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
-				return
-			}
-			if !yieldTracked(NewServerEventMsg(msg.SubscriptionID, event)) {
-				h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
-				return
-			}
-			eventsSent++
-		}
-
-		// Distinguish timeout from other errFn failures. Storage impls
-		// that respect ctx may surface context.DeadlineExceeded via
-		// errFn; treat that the same as a ctx.Err-driven abort.
-		if ctx.Err() != nil || errors.Is(errFn(), context.DeadlineExceeded) {
-			yieldTracked(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
 			h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
-			return
+			return err
 		}
-
-		if err := errFn(); err != nil {
-			LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err, "subscription_id", msg.SubscriptionID)
-			yieldTracked(NewServerEOSEMsg(msg.SubscriptionID))
-			h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, true)
-			return
+		if aborted {
+			break
 		}
+		eventsSent++
+	}
 
-		// Send EOSE to signal end of stored events
-		yieldTracked(NewServerEOSEMsg(msg.SubscriptionID))
-		h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, true)
-	}, nil
+	// Terminal-message decision. A queryCtx failure while outer ctx is
+	// still alive means QueryTimeout fired → send CLOSED. Storage impls
+	// that respect ctx may also surface context.DeadlineExceeded via
+	// errFn; treat that the same as a queryCtx-driven abort.
+	if (queryCtx.Err() != nil && ctx.Err() == nil) ||
+		errors.Is(errFn(), context.DeadlineExceeded) {
+		// Emit CLOSED on the outer ctx. If outer ctx is cancelled the
+		// send will just fail and we'll return its err — the connection
+		// is going away anyway.
+		s := time.Now()
+		err := sendServerMsg(ctx, send, NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
+		sendWait += time.Since(s)
+		h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, false)
+		return err
+	}
+
+	if err := errFn(); err != nil {
+		LoggerFromContext(ctx).WarnContext(ctx, "query error", "error", err, "subscription_id", msg.SubscriptionID)
+		// Even on query error we still try to send EOSE so the client
+		// isn't left hanging — matches prior behavior.
+	}
+
+	// Send EOSE to signal end of stored events.
+	s := time.Now()
+	err := sendServerMsg(ctx, send, NewServerEOSEMsg(msg.SubscriptionID))
+	sendWait += time.Since(s)
+	h.maybeLogSlowReq(ctx, msg, start, sendWait, eventsSent, err == nil)
+	return err
 }
 
-func (h *storageHandler) handleCount(ctx context.Context, msg *ClientMsg) (iter.Seq[*ServerMsg], error) {
-	return func(yield func(*ServerMsg) bool) {
-		if msg.SubscriptionID == "" {
-			return
+func (h *storageHandler) handleCount(
+	ctx context.Context,
+	send chan<- *ServerMsg,
+	msg *ClientMsg,
+) error {
+	if msg.SubscriptionID == "" {
+		return nil
+	}
+
+	// COUNT emits a single terminal message, so there is no meaningful
+	// send-wait component during iteration — total duration is dominated
+	// by scan. start is taken before Query so iterator-initialization
+	// cost counts toward total.
+	start := time.Now()
+
+	queryCtx := ctx
+	if h.queryTimeout > 0 {
+		var cancel context.CancelFunc
+		queryCtx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+		defer cancel()
+	}
+
+	events, errFn, closeFn := h.storage.Query(queryCtx, msg.Filters)
+	defer closeFn()
+
+	var count uint64
+	for range events {
+		if queryCtx.Err() != nil {
+			break
 		}
+		count++
+	}
 
-		// COUNT emits a single terminal message, so there is no
-		// meaningful send-wait component during iteration — total
-		// duration is dominated by scan. start is taken before Query so
-		// iterator-initialization cost counts toward total.
-		start := time.Now()
-
-		if h.queryTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
-			defer cancel()
-		}
-
-		events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
-		defer closeFn()
-
-		count := uint64(0)
-		for range events {
-			if ctx.Err() != nil {
-				yield(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
-				h.maybeLogSlowCount(ctx, msg, start, count)
-				return
-			}
-			count++
-		}
-
-		if ctx.Err() != nil || errors.Is(errFn(), context.DeadlineExceeded) {
-			yield(NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
-			h.maybeLogSlowCount(ctx, msg, start, count)
-			return
-		}
-
-		if err := errFn(); err != nil {
-			LoggerFromContext(ctx).WarnContext(ctx, "count query error", "error", err, "subscription_id", msg.SubscriptionID)
-			yield(NewServerCountMsg(msg.SubscriptionID, 0, nil))
-			h.maybeLogSlowCount(ctx, msg, start, count)
-			return
-		}
-
-		yield(NewServerCountMsg(msg.SubscriptionID, count, nil))
+	if (queryCtx.Err() != nil && ctx.Err() == nil) ||
+		errors.Is(errFn(), context.DeadlineExceeded) {
+		err := sendServerMsg(ctx, send, NewServerClosedMsg(msg.SubscriptionID, queryTimeoutCLOSEDReason))
 		h.maybeLogSlowCount(ctx, msg, start, count)
-	}, nil
+		return err
+	}
+
+	if err := errFn(); err != nil {
+		LoggerFromContext(ctx).WarnContext(ctx, "count query error", "error", err, "subscription_id", msg.SubscriptionID)
+		sendErr := sendServerMsg(ctx, send, NewServerCountMsg(msg.SubscriptionID, 0, nil))
+		h.maybeLogSlowCount(ctx, msg, start, count)
+		return sendErr
+	}
+
+	err := sendServerMsg(ctx, send, NewServerCountMsg(msg.SubscriptionID, count, nil))
+	h.maybeLogSlowCount(ctx, msg, start, count)
+	return err
 }
 
 // maybeLogSlowReq emits a Warn log when the REQ total duration exceeds the

--- a/storage_handler.go
+++ b/storage_handler.go
@@ -111,17 +111,67 @@ type storageHandler struct {
 	queryTimeout time.Duration
 }
 
+// storageHandlerMsgQueueBuffer sizes the internal queue between the
+// recv-drain goroutine and the main loop. Any positive cap guarantees recv
+// drain never fully stops while the main loop is parked on a yield's
+// send<-msg. 10 mirrors [simpleHandlerMsgQueueBuffer] and
+// MergeHandler.childRecvs so all three layers share the same backpressure
+// budget.
+const storageHandlerMsgQueueBuffer = 10
+
 func (h *storageHandler) ServeNostr(
 	ctx context.Context,
 	send chan<- *ServerMsg,
 	recv <-chan *ClientMsg,
 ) error {
+	// Decouple recv drain from response forwarding. handleReq's iter.Seq
+	// loop forwards events to send<-msg on this same goroutine, so a
+	// stalled receiver would otherwise stop recv drain entirely. Under an
+	// upstream MergeHandler (childRecvs cap 10) that wedges into the
+	// "deadlock spring" shape recorded in CLAUDE.md and the diary entry
+	// for 2026-04-24: childSends fills, yield blocks, recv stops draining,
+	// childRecvs fills, broadcastAll trips BroadcastTimeout, child gets
+	// retired. simpleHandler solved the same problem in #78; the CLAUDE.md
+	// rule "Handlers that implement Handler directly and consume iter.Seq
+	// responses must follow the same shape" applies here verbatim.
+	//
+	// drainCtx is a sub-ctx of the connection ctx. `defer drainCancel()`
+	// runs on every main-loop return path (ctx cancel, msgQueue close /
+	// recv close, handle* error, normal completion), so the drain
+	// goroutine is reliably reaped without depending on caller-side ctx
+	// cancel — important for third-party callers invoking ServeNostr
+	// directly. Recv close additionally closes msgQueue, which drives the
+	// main loop to return nil naturally.
+	drainCtx, drainCancel := context.WithCancel(ctx)
+	defer drainCancel()
+	msgQueue := make(chan *ClientMsg, storageHandlerMsgQueueBuffer)
+	go func() {
+		defer close(msgQueue)
+		for {
+			select {
+			case <-drainCtx.Done():
+				return
+			case msg, ok := <-recv:
+				if !ok {
+					return
+				}
+				select {
+				case <-drainCtx.Done():
+					return
+				case msgQueue <- msg:
+				}
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case msg, ok := <-recv:
+		case msg, ok := <-msgQueue:
 			if !ok {
+				// recv was closed (drain goroutine returned and
+				// closed msgQueue); client disconnected.
 				return nil
 			}
 			switch msg.Type {

--- a/storage_handler_test.go
+++ b/storage_handler_test.go
@@ -3,6 +3,7 @@ package mocrelay
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"iter"
 	"log/slog"
 	"strings"
@@ -697,5 +698,75 @@ func TestStorageHandler_QueryTimeout_NegativeDisables(t *testing.T) {
 		require.Len(t, msgs, 2)
 		assert.Equal(t, MsgTypeEvent, msgs[0].Type)
 		assert.Equal(t, MsgTypeEOSE, msgs[1].Type)
+	})
+}
+
+// TestStorageHandler_QueryTimeout_ReqAbortsOnStalledConsumer exercises the
+// "live but slow client" class of stall — the motivating case that
+// QueryTimeout was introduced for. Query returns fast but the receiver
+// stops draining send, so the handler's yield blocks on send<-msg.
+// QueryTimeout must fire at the *send boundary* too: a ctx.WithTimeout
+// scoped to Query alone lets the stall continue indefinitely once yield
+// is blocked (scan is already done; the scan loop's ctx.Err check never
+// re-runs).
+func TestStorageHandler_QueryTimeout_ReqAbortsOnStalledConsumer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		base := NewInMemoryStorage()
+		// Populate more than one event so there is a second yield that
+		// actually stalls on send<-msg (the first fits in the
+		// receiver-side handoff that the test performs below).
+		for i := range 5 {
+			base.Store(ctx, makeEvent(
+				fmt.Sprintf("event-%02d", i),
+				"pubkey01",
+				1,
+				int64(100+i),
+			))
+		}
+
+		handler := NewStorageHandler(base, &StorageHandlerOptions{
+			QueryTimeout:       100 * time.Millisecond,
+			SlowQueryThreshold: 50 * time.Millisecond,
+		})
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		send := make(chan *ServerMsg) // unbuffered: 2nd yield stalls
+		recv := make(chan *ClientMsg, 1)
+		errCh := make(chan error, 1)
+		go func() { errCh <- handler.ServeNostr(ctx, send, recv) }()
+
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{}},
+		}
+
+		// Receive exactly one EVENT, then stop draining so the next yield
+		// blocks. The handler is now parked on send<-msg for event #2.
+		first := <-send
+		require.Equal(t, MsgTypeEvent, first.Type)
+
+		// Advance the fake clock well past QueryTimeout. A correctly
+		// scoped QueryTimeout must unblock the stalled send and fall
+		// through to the CLOSED abort path.
+		time.Sleep(300 * time.Millisecond)
+		synctest.Wait()
+
+		// The next message the handler sends must be CLOSED, not another
+		// EVENT — time has moved past the abort deadline.
+		select {
+		case msg := <-send:
+			assert.Equal(t, MsgTypeClosed, msg.Type)
+			assert.Equal(t, "sub1", msg.SubscriptionID)
+			assert.Equal(t, queryTimeoutCLOSEDReason, msg.Message)
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("handler did not send CLOSED after QueryTimeout — send-side stall is not honoring the timeout")
+		}
+
+		cancel()
+		synctest.Wait()
+		<-errCh
 	})
 }

--- a/storage_handler_test.go
+++ b/storage_handler_test.go
@@ -770,3 +770,97 @@ func TestStorageHandler_QueryTimeout_ReqAbortsOnStalledConsumer(t *testing.T) {
 		<-errCh
 	})
 }
+
+// TestStorageHandler_DrainsRecvWhileYieldBlocks asserts that storageHandler
+// keeps draining its recv channel while a REQ response is parked on
+// send<-msg. The motivating concern is the "deadlock spring" shape recorded
+// in CLAUDE.md: when a Handler implements [Handler] directly (as
+// storageHandler does, since #76) and consumes its iter.Seq response on the
+// same goroutine that reads recv, a stalled send pauses recv drain — which
+// in turn wedges upstream broadcasters such as MergeHandler on their own
+// child-recv buffers (childRecvs cap 10) until BroadcastTimeout retires the
+// child.
+//
+// simpleHandler addressed this in #78 by spawning a dedicated recv-drain
+// goroutine fed by an internal cap-10 queue. The CLAUDE.md rule "Handlers
+// that implement Handler directly and consume iter.Seq responses must
+// follow the same shape" applies to storageHandler too: this test exercises
+// that contract.
+func TestStorageHandler_DrainsRecvWhileYieldBlocks(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		base := NewInMemoryStorage()
+		// Two events: the first event is delivered into the unbuffered send
+		// below, the second yield then blocks on send<-msg. That blocked
+		// send is the condition we want to verify recv drain survives.
+		for i := range 2 {
+			base.Store(t.Context(), makeEvent(
+				fmt.Sprintf("event-%02d", i),
+				"pubkey01",
+				1,
+				int64(100+i),
+			))
+		}
+
+		// QueryTimeout left at zero (disabled) on purpose: the test must
+		// observe recv drain survival on the indefinite-stall path that
+		// QueryTimeout would otherwise mask.
+		handler := NewStorageHandler(base, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		send := make(chan *ServerMsg) // unbuffered: 2nd yield stalls
+		recv := make(chan *ClientMsg) // unbuffered: drain pauses are observable
+
+		done := make(chan error, 1)
+		go func() { done <- handler.ServeNostr(ctx, send, recv) }()
+
+		// Push a REQ. The handler will yield event-00, drain it via the
+		// receive on `send` below, then yield event-01 — at which point
+		// the main loop is parked on send<-msg with `send` having no
+		// further reader.
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{}},
+		}
+		first := <-send
+		require.Equal(t, MsgTypeEvent, first.Type)
+		synctest.Wait()
+
+		// Push a second client message. With concurrent recv drain (the
+		// desired behaviour), this push completes even though the main
+		// loop is still parked on the first response's stalled send. We
+		// don't need the handler to *act on* the second message — just to
+		// keep flowing recv. Push from a helper goroutine so we can
+		// distinguish "push succeeded" from "push is still blocked"; make
+		// it ctx-aware so the final cancel cleanup reliably reaps it.
+		delivered := make(chan struct{})
+		go func() {
+			select {
+			case recv <- &ClientMsg{Type: MsgTypeEvent}:
+			case <-ctx.Done():
+			}
+			close(delivered)
+		}()
+		synctest.Wait()
+
+		var drainStalled bool
+		select {
+		case <-delivered:
+			t.Log("storageHandler drained recv while yield was blocked (ideal)")
+		default:
+			drainStalled = true
+		}
+
+		cancel()
+		synctest.Wait()
+		<-done
+
+		if drainStalled {
+			t.Fatal("storageHandler stopped draining recv while a REQ " +
+				"response was blocked on send — this is the 'deadlock " +
+				"spring' shape that wedges MergeHandler childRecvs at " +
+				"production scale (CLAUDE.md iter.Seq recv-drain rule).")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Fix the [QueryTimeout](https://github.com/high-moctane/mocrelay/pull/73) context-scoping bug so REQ / COUNT stalls can actually be aborted at the `send<-msg` boundary, not just during scan.
- Reimplement `StorageHandler` as a direct `Handler` (no longer wrapped by `SimpleHandlerBase`) so the timeout ctx can cover the exact send sites that stall.
- Adopt the iter.Seq recv-drain pattern recorded in CLAUDE.md (rule introduced by #78): decouple recv drain from response forwarding so a stalled `send<-msg` can no longer stop recv drain entirely. Without this, the new direct-`Handler` form would violate the rule and re-introduce the "deadlock spring" shape for the duration of `QueryTimeout` every time it fires.
- Tests:
  - `TestStorageHandler_QueryTimeout_ReqAbortsOnStalledConsumer` — the original regression test (failing on `main`, passing here).
  - `TestStorageHandler_DrainsRecvWhileYieldBlocks` — new recv-drain test, mirrors `TestSimpleHandler_DrainsRecvWhileYieldBlocks` from #78.

## Why (QueryTimeout scope)

Production logs on salmon (over a recent 24 h window) showed REQ subscriptions with `send_wait_ms > 3 h` while:

- `conn.Write` stayed at ~5 ms per call (no write_timeout metric trips),
- `ping_timeout` never fired (client kept round-tripping pongs),
- the connection eventually closed with `io.EOF` (client-initiated TCP close).

That is the exact "live but slow client" case [#73](https://github.com/high-moctane/mocrelay/pull/73) introduced QueryTimeout for — and yet REQs were surviving 19× the configured 10 min timeout. Tracing the flow showed why.

## Bug 1: QueryTimeout scope

In the prior implementation, `handleReq` wrapped the timeout inside its `iter.Seq` closure:

```go
return func(yield func(*ServerMsg) bool) {
    if h.queryTimeout > 0 {
        ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
        defer cancel()
    }
    events, errFn, closeFn := h.storage.Query(ctx, msg.Filters)
    for event := range events {
        if ctx.Err() != nil { ... break }       // only polled here
        if !yieldTracked(NewServerEventMsg(...)) { return }
        eventsSent++
    }
}
```

The closure-local `ctx` only reaches `storage.Query`. The yield itself — which forwards through `SimpleHandlerBase.ServeNostr`'s `send<-msg` — uses the *outer* connection ctx, which has no deadline. Once a receiver stalls, the inner `ctx.Err` check never re-runs because yield blocks before the next iteration starts. Result: QueryTimeout covered only the scan phase, not the send-wait phase it was specifically introduced to address.

### Fix

Reimplement `StorageHandler` as a direct `Handler` so it can own its `ServeNostr` loop and attach `queryCtx` to the exact send sites that can stall. Key points:

- `queryCtx := ctx.WithTimeout(ctx, QueryTimeout)` derived once per REQ / COUNT.
- `storage.Query(queryCtx, filters)` — scan still respects the deadline.
- Every event emission uses `select { send<-msg; <-queryCtx.Done() }`.
- `queryCtx.Err()` polled at the top of each iteration (fast-path abort).
- Terminal `CLOSED` emitted on the outer ctx so it can outlive `queryCtx`.
- Outer ctx cancellation (connection ending) surfaces as `ctx.Err()` through `ServeNostr`, same as before.

## Bug 2: iter.Seq recv-drain — surfaced by #78

While Bug 1 was on the wire as a draft, [#78](https://github.com/high-moctane/mocrelay/pull/78) landed on `main` with a new CLAUDE.md rule:

> Handlers that implement `Handler` directly and consume `iter.Seq` responses must follow the same shape.

Bug 1's fix moves `StorageHandler` from `SimpleHandlerBase` to a direct `Handler` — exactly the case the rule targets. After rebasing on main I confirmed it: the new `storageHandler.ServeNostr` reads `recv` and forwards REQ responses through `handleReq`'s yield loop on the same goroutine, so a stalled receiver halts recv drain entirely. Under an upstream `MergeHandler` (childRecvs cap 10) this wedges into the deadlock-spring shape recorded in the diary for 2026-04-24.

The interaction with Bug 1 is the operationally important part: without this second fix, every `QueryTimeout` firing would produce the spring shape for `QueryTimeout` ms before the abort kicks in. For the salmon configuration that is up to 10 minutes of `MergeHandler` broadcast wedging per slow REQ — a strict regression compared to the pre-#76 behaviour.

### Fix

Port simpleHandler's pattern (#78) verbatim:

- Spawn a dedicated recv-drain goroutine fed by a cap-10 internal queue (`storageHandlerMsgQueueBuffer`, mirroring `simpleHandlerMsgQueueBuffer` and `MergeHandler.childRecvs` — all three layers share the same backpressure budget; only ≥1 is required for correctness).
- Main loop consumes from `msgQueue`, dispatches to `handleEvent` / `handleReq` / `handleCount`, forwards responses on `send`.
- `drainCtx` is a sub-ctx of the connection ctx with `defer drainCancel()` at handler scope, so the drain goroutine is reliably reaped on every main-loop return path without depending on caller-side cancellation — matches the self-contained shape the #78 review feedback tightened.

## Public API impact

None visible. `NewStorageHandler` still returns `Handler`. The internal wrapping via `SimpleHandler(&storageHandler{...})` is gone; now it returns `&storageHandler{...}` directly. Anything type-asserting on the internal shape was already relying on unexported implementation.

## Tests

### `TestStorageHandler_QueryTimeout_ReqAbortsOnStalledConsumer`

Unbuffered send channel → handler delivers 1 EVENT, stalls on the 2nd send → test advances synctest's fake clock past QueryTimeout → asserts the next message is `CLOSED "error: query timeout"`, not another EVENT.

- On `main` (before this change): test fails with the 2nd EVENT being delivered (handler ignores the timeout at the send boundary).
- On this branch: test passes.

### `TestStorageHandler_DrainsRecvWhileYieldBlocks` (new)

Direct mirror of `TestSimpleHandler_DrainsRecvWhileYieldBlocks` from #78, applied to storageHandler. Pushes a REQ with two stored events, drains one EVENT to park the main loop on the second yield's `send<-msg`, then pushes a second client message from a helper goroutine and asserts the push completes — i.e. recv drain continues even while yield is stalled.

- On the post-rebase pre-fix commit: fails with the deadlock-spring message (recv drain stops the moment yield blocks).
- On this branch: passes — drain goroutine keeps recv flowing independently of the main loop's yield state.

All existing StorageHandler tests — including the existing QueryTimeout tests that exercise the *scan* path — continue to pass. Full suite + `go test -race ./...` clean.

## Out of scope (but discovered during investigation)

- `go test -race` flags a pre-existing DATA RACE in MergeHandler / metrics tests (`TestMergeHandler_Broadcast_REQTimeoutAdvances`, `TestMergeHandler_Broadcast_OKForcedFalseOnTimeout`, `TestMetrics_MergeHandler_LostChildAndBroadcastTimeout`). Originally reproducible on `main` as of 6d25455 — not introduced by this PR. Worth a separate ticket. (Re-verifying against the current `main` head after the post-#76 churn is itself a follow-up.)
- The salmon logs also show cases where connections stayed alive for 3 h despite the stall, even though ping/pong should have caught a dead receiver. A separate investigation is in progress using the block profile infrastructure deployed in moctane-mocrelay 67d36ad + mocvps e04bff7. That problem is orthogonal to the QueryTimeout bug fixed here.

## Follow-ups

- After merge + release, bump moctane-mocrelay's mocrelay dep to pick up both fixes.
- Observe whether new slow-REQ logs show `completed=false` at ~QueryTimeout (expected: yes) rather than scaling with receiver stall time, *and* whether `MergeHandler` broadcast-timeout logs no longer correlate with slow REQs (expected: no correlation, since recv drain now survives independently of yield state).

🐛 Generated with [Claude Code](https://claude.com/claude-code)