### PR TITLE
fix: cancel dead-retired child via per-child sub-ctx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -849,6 +849,15 @@ if newEvent.CreatedAt > lastSentCreatedAt {
   child and never restarts it; a Handler that wraps a recoverable
   external resource (e.g. an upstream relay) should absorb short-term
   contention and reconnect internally.
+- Each child runs under its **own cancelable sub-ctx** of the
+  merge-wide ctx, and a retired child's sub-ctx is canceled
+  immediately (on BroadcastTimeout or send-channel close) — not at
+  end-of-connection. Sharing the merge-wide ctx across children would
+  leak a retired child's goroutine (and any held subscription /
+  storage cursor resources) for the lifetime of the connection,
+  manifesting at production scale as a "live but slow client" REQ
+  wedging the relay even with `StorageHandlerOptions.QueryTimeout`
+  set.
 
 **Handler contract for use under MergeHandler**:
 - A Handler MUST drain its `recv` channel in a timely fashion. Brief
@@ -860,6 +869,12 @@ if newEvent.CreatedAt > lastSentCreatedAt {
 - A Handler that exits early (`return err`) leaves its child recv channel
   alive but unread; MergeHandler sees the close-of-childSends and runs
   `handlerClosed`. No additional cleanup is required from the Handler.
+- When MergeHandler retires a Handler (BroadcastTimeout hit or
+  send-channel self-close), it cancels that Handler's ctx immediately
+  — not at end-of-connection. Handlers that block on `<-ctx.Done()`
+  observe the cancel promptly upon retirement, and any cleanup /
+  resource release tied to ctx cancel runs in the per-child window
+  rather than the merge-wide window.
 
 **Considerations**:
 - If a handler never sends EOSE *and* never gets retired, session maps

--- a/merge_handler.go
+++ b/merge_handler.go
@@ -228,9 +228,14 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 			if err := handler.ServeNostr(childCtxs[i], childSends[i], childRecvs[i]); err != nil {
 				logger := LoggerFromContext(ctx)
 				if errors.Is(err, context.Canceled) {
-					// Normal shutdown path: parent ctx was canceled and the
-					// child propagated it back. Not worth a Warn — Relay
-					// already logs "connection end (canceled)" at Info.
+					// Normal shutdown path: either the merge-wide parent
+					// ctx or this child's per-child sub-ctx (canceled on
+					// retire — BroadcastTimeout hit or send-channel
+					// self-close) was canceled, and the child propagated
+					// it back. Not worth a Warn — Relay already logs
+					// "connection end (canceled)" at Info, and retirement
+					// is logged separately at Warn in broadcastAll / the
+					// default branch.
 					logger.DebugContext(ctx,
 						"merge handler: child canceled",
 						"handler_index", i,

--- a/merge_handler.go
+++ b/merge_handler.go
@@ -184,6 +184,26 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 	logger := LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "merge handler: started", "num_handlers", numHandlers)
 
+	// Per-child cancelable sub-ctx. Retiring a child on BroadcastTimeout
+	// or early send-channel close must cancel that child's ServeNostr
+	// directly; otherwise the child keeps blocking on <-ctx.Done() for
+	// the merge-wide ctx and only exits when the entire connection
+	// unwinds — leaking the goroutine (and any held subscription /
+	// storage cursor resources) for potentially minutes until the
+	// client disconnects. At production scale this manifested as a
+	// "live but slow client" REQ wedging the relay even with
+	// StorageHandlerOptions.QueryTimeout set.
+	childCtxs := make([]context.Context, numHandlers)
+	childCancels := make([]context.CancelFunc, numHandlers)
+	for i := range h.handlers {
+		childCtxs[i], childCancels[i] = context.WithCancel(ctx)
+	}
+	defer func() {
+		for _, c := range childCancels {
+			c()
+		}
+	}()
+
 	// Create channels for each child handler. childRecvs uses an internal
 	// default buffer size; childSends is fixed because the merger drains it
 	// directly from the main loop and no buffering matters beyond a small
@@ -205,7 +225,7 @@ func (h *mergeHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, r
 		go func(i int, handler Handler) {
 			defer wg.Done()
 			defer close(childSends[i])
-			if err := handler.ServeNostr(ctx, childSends[i], childRecvs[i]); err != nil {
+			if err := handler.ServeNostr(childCtxs[i], childSends[i], childRecvs[i]); err != nil {
 				logger := LoggerFromContext(ctx)
 				if errors.Is(err, context.Canceled) {
 					// Normal shutdown path: parent ctx was canceled and the
@@ -290,6 +310,13 @@ loop:
 				break loop
 			}
 			for _, idx := range deadIndices {
+				// Release the retired child's goroutine immediately.
+				// Without this cancel, the child keeps blocking on the
+				// shared merge-wide ctx and leaks until the connection
+				// unwinds — the exact scenario
+				// TestMergeHandler_DeadChild_GoroutineReleasedPromptly
+				// pins down.
+				childCancels[idx]()
 				cases[2+idx].Chan = reflect.ValueOf(nil)
 				childRecvs[idx] = nil
 				if h.metrics != nil {
@@ -307,12 +334,19 @@ loop:
 			if !ok {
 				// Child closed: disable this case and advance any pending
 				// state still waiting on this handler so the client isn't
-				// left hanging on OK / EOSE / COUNT.
+				// left hanging on OK / EOSE / COUNT. Also cancel the
+				// child's sub-ctx (idempotent; the child is already
+				// returning) and nil the recv channel so subsequent
+				// broadcasts skip this index — otherwise a later control
+				// message would push into a recv buffer nobody is
+				// draining and trip BroadcastTimeout again.
 				LoggerFromContext(ctx).WarnContext(ctx,
 					"merge handler: child closed its send channel",
 					"handler_index", handlerIndex,
 				)
+				childCancels[handlerIndex]()
 				cases[chosen].Chan = reflect.ValueOf(nil)
+				childRecvs[handlerIndex] = nil
 				if h.metrics != nil {
 					h.metrics.LostChildrenTotal.Inc()
 				}

--- a/merge_handler_test.go
+++ b/merge_handler_test.go
@@ -1712,6 +1712,10 @@ func TestMergeHandler_DeadChild_GoroutineReleasedPromptly(t *testing.T) {
 			Filters:        []*ReqFilter{{}},
 		}
 
+		// 2× broadcastTimeout (100ms) under synctest's fake clock: long
+		// enough for the Slow-path timer in broadcastAll to fire and flip
+		// the child to dead-retired, before we assert on the post-retire
+		// goroutine state.
 		time.Sleep(200 * time.Millisecond)
 		synctest.Wait()
 

--- a/merge_handler_test.go
+++ b/merge_handler_test.go
@@ -1644,3 +1644,106 @@ func TestMergeHandler_Broadcast_OKForcedFalseOnTimeout(t *testing.T) {
 		<-errCh
 	})
 }
+
+// trackedStuckHandler is stuckHandler + a signal that fires when ServeNostr
+// returns. Used to assert on child-goroutine lifecycle (released vs leaked)
+// independently from merge-level merged-response behaviour.
+type trackedStuckHandler struct {
+	returned chan struct{}
+}
+
+func (h *trackedStuckHandler) ServeNostr(
+	ctx context.Context,
+	send chan<- *ServerMsg,
+	recv <-chan *ClientMsg,
+) error {
+	defer close(h.returned)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestMergeHandler_DeadChild_GoroutineReleasedPromptly asserts that when a
+// child handler is declared dead by BroadcastTimeout, its goroutine is
+// released promptly — not left running until the whole merge connection
+// ends.
+//
+// Today this test is EXPECTED TO FAIL on main: dead-retired children share
+// the merge-wide ctx and only observe cancel when the entire connection
+// unwinds. The symptom at production scale (salmon) is a "live but slow
+// client" REQ that wedges for tens of minutes even with QueryTimeout set,
+// because the merge parent loop silently ignores the retired child's
+// childSends[i] (cases[2+idx].Chan = nil) while the child keeps pushing
+// events into that channel until it blocks on cap=10.
+//
+// The structural fix (future PR) is to give each child its own cancelable
+// sub-ctx and cancel it at the moment handlerClosed runs on broadcast
+// timeout. Once that lands, this test should PASS as-written.
+func TestMergeHandler_DeadChild_GoroutineReleasedPromptly(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		child := &trackedStuckHandler{returned: make(chan struct{})}
+
+		mergeHandler := &mergeHandler{
+			handlers:         []Handler{child},
+			broadcastTimeout: 100 * time.Millisecond,
+			childRecvBuffer:  1,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		send := make(chan *ServerMsg, 32)
+		recv := make(chan *ClientMsg, 32)
+
+		mergeErr := make(chan error, 1)
+		go func() {
+			mergeErr <- mergeHandler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Fill child's recv buffer (cap=1) — first REQ succeeds fast-path.
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{}},
+		}
+		// Second REQ trips the slow path → BroadcastTimeout → dead retire.
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub2",
+			Filters:        []*ReqFilter{{}},
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		// At this point, child should be dead-retired. handlerClosed has
+		// advanced the pending EOSEs; drain them so we're looking at a
+		// post-retirement state.
+	drain:
+		for {
+			select {
+			case <-send:
+			default:
+				break drain
+			}
+		}
+
+		// Ideal behaviour (post-fix): the child's ServeNostr has returned
+		// because the merge handler canceled its per-child sub-ctx.
+		// Current behaviour (buggy): the child is still blocked on
+		// <-ctx.Done() because the merge-wide ctx has not been canceled.
+		select {
+		case <-child.returned:
+			t.Log("child goroutine released promptly after dead-retire (ideal)")
+		default:
+			t.Fatal("dead-retired child goroutine is still running " +
+				"(leak): expected per-child ctx to be canceled " +
+				"immediately after BroadcastTimeout, but the child is " +
+				"still waiting on merge-wide ctx.Done().")
+		}
+
+		cancel()
+		synctest.Wait()
+		<-mergeErr
+		<-child.returned
+	})
+}


### PR DESCRIPTION
## Summary

- Give each child handler its own cancelable sub-ctx of the merge-wide ctx, and cancel it immediately when the child is retired (BroadcastTimeout hit, or early send-channel close).
- Also nil out `childRecvs[i]` in the self-close path so a later control message can't trip BroadcastTimeout again against an already-gone child.
- Add `TestMergeHandler_DeadChild_GoroutineReleasedPromptly` in TDD style (RED commit before the fix commit, GREEN after), and document the new contract in `CLAUDE.md`.

## Context

Observed at production scale on salmon: a "live but slow client" REQ wedged the relay even with `StorageHandlerOptions.QueryTimeout` set. Investigation flow across the previous two sessions:

1. **Prometheus diagnosis** — slow-REQ logs consistently showed `events_sent=10`, matching the `childSends[i]` cap of 10. That pointed at parent-loop stall, not scan-side or write-side latency.
2. **Rubber-duck debug** — reading `reflect.Select` line by line surfaced six suspicious spots. The decisive one: dead-retired children only had `cases[2+idx].Chan` nil'd, so their goroutines still shared the merge-wide ctx and blocked on `<-ctx.Done()` until end-of-connection. The retired child kept pushing into `childSends[i]` until it filled cap=10 and blocked there — the parent loop silently ignored that case, and the storage `iter.Seq` was pull-paused for the duration of the connection.
3. **This PR** — per-child sub-ctx + immediate cancel on retire. The child observes `ctx.Done()` promptly, returns, and its `close(childSends[i])` cleans up in the usual way.

See the `CLAUDE.md` diff for the narrative that now lives in the repo.

## Test plan

- [x] `TestMergeHandler_DeadChild_GoroutineReleasedPromptly` flips RED → GREEN across the two commits (reproduced locally).
- [x] Full `go test -race -count=1 ./...` passes, no regressions.
- [ ] Spirits review (🦍🍍🍋) before taking out of draft.
- [ ] Deploy to salmon after merge (moctane-mocrelay → mocvps → salmon) and confirm slow-query logs no longer show indefinite wedges.

🦆 Generated with [Claude Code](https://claude.com/claude-code)