### PR TITLE
fix: decouple recv drain from response forwarding in simpleHandler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,18 @@ Resolution: split recv drain into a dedicated goroutine with a bounded
 internal queue. `simpleHandler` does this with
 `simpleHandlerMsgQueueBuffer = 10`; any queue depth ≥ 1 is sufficient
 for the invariant "recv drain never fully stops while yield is
-blocked", and the outer ctx cancel (every in-module `ServeNostr`
-caller cancels ctx immediately after return) reliably reaps the drain
-goroutine on all return paths.
+blocked". The drain goroutine runs under a sub-ctx canceled by `defer`
+on every main-loop return path, so it is reliably reaped without
+depending on caller-side ctx cancel — important for third-party code
+that calls `ServeNostr` directly.
+
+When `msgQueue` itself fills (sustained slow consumer that cannot
+drain the send side), the drain goroutine naturally blocks on
+`msgQueue <- msg`, propagating backpressure upstream (MergeHandler
+`childRecvs` → Relay read loop → the WebSocket peer). In practice
+Relay's 10s write timeout disconnects the slow consumer long before
+cap 10 matters, so the bound exists as a conservative margin aligned
+with MergeHandler rather than as a correctness requirement.
 
 Handlers that implement `Handler` directly and consume `iter.Seq`
 responses must follow the same shape. Handlers composed via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,36 @@ default:
 - Usually completes in milliseconds, acceptable
 - Long blocking indicates bigger problems
 
+**iter.Seq response with concurrent recv drain**:
+
+When a Handler returns `iter.Seq[*ServerMsg]` from `HandleMsg` and
+consumes it on the same goroutine that reads `recv`, a blocked
+`send <- msg` inside the yield loop also stops recv drain. Under an
+upstream broadcaster with a small buffer (e.g. `MergeHandler.childRecvs`,
+cap 10) this wedges into a "deadlock spring":
+
+```text
+Storage yields → childSends (cap 10) fills → yield blocks on send
+  → simpleHandler stops reading recv
+  → MergeHandler childRecvs fills on the next client msg
+  → broadcastAll hits BroadcastTimeout → child retired
+```
+
+Resolution: split recv drain into a dedicated goroutine with a bounded
+internal queue. `simpleHandler` does this with
+`simpleHandlerMsgQueueBuffer = 10`; any queue depth ≥ 1 is sufficient
+for the invariant "recv drain never fully stops while yield is
+blocked", and the outer ctx cancel (every in-module `ServeNostr`
+caller cancels ctx immediately after return) reliably reaps the drain
+goroutine on all return paths.
+
+Handlers that implement `Handler` directly and consume `iter.Seq`
+responses must follow the same shape. Handlers composed via
+`NewSimpleMiddleware` are already fine — its pipeline loop uses a
+nil-channel + pending-queue form, and middleware HandleClientMsg /
+HandleServerMsg return a single value rather than an iterator, so the
+spooling risk that blocks the iter.Seq path does not apply.
+
 ### Memory Leak Prevention (State Management)
 
 **Problem**: If a Handler holds per-subscription state and the connection drops without CLOSE, state may persist.

--- a/handler.go
+++ b/handler.go
@@ -64,6 +64,12 @@ type simpleHandler struct {
 	base SimpleHandlerBase
 }
 
+// simpleHandlerMsgQueueBuffer sizes the internal queue between the recv-drain
+// goroutine and the main loop. Any positive cap guarantees recv drain never
+// fully stops while the main loop is blocked yielding a response. 10 mirrors
+// MergeHandler.childRecvs so both layers share the same backpressure budget.
+const simpleHandlerMsgQueueBuffer = 10
+
 func (h *simpleHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, recv <-chan *ClientMsg) (err error) {
 	ctx, startMsg, startErr := h.base.OnStart(ctx)
 	if startErr != nil {
@@ -90,12 +96,45 @@ func (h *simpleHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, 
 		}
 	}
 
+	// Decouple recv drain from response forwarding. A blocked `send <- msg`
+	// in the main loop below must not stop recv drain — otherwise a slow
+	// downstream wedges the whole handler and upstream broadcasters (e.g.
+	// MergeHandler) pile up on their own child-recv buffers. This is the
+	// "deadlock spring" shape observed at production scale
+	// (diary 2026-04-24).
+	//
+	// The drain goroutine exits on either:
+	//   - ctx cancel (caller-driven shutdown — every ServeNostr caller in
+	//     this module cancels ctx immediately after ServeNostr returns, so
+	//     a main-loop return reliably reaps this goroutine).
+	//   - recv close (client disconnect); closing msgQueue then drives the
+	//     main loop to return nil naturally.
+	msgQueue := make(chan *ClientMsg, simpleHandlerMsgQueueBuffer)
+	go func() {
+		defer close(msgQueue)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-recv:
+				if !ok {
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case msgQueue <- msg:
+				}
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case msg, ok := <-recv:
+		case msg, ok := <-msgQueue:
 			if !ok {
 				// recv channel closed, client disconnected
 				return nil

--- a/handler.go
+++ b/handler.go
@@ -103,25 +103,28 @@ func (h *simpleHandler) ServeNostr(ctx context.Context, send chan<- *ServerMsg, 
 	// "deadlock spring" shape observed at production scale
 	// (diary 2026-04-24).
 	//
-	// The drain goroutine exits on either:
-	//   - ctx cancel (caller-driven shutdown — every ServeNostr caller in
-	//     this module cancels ctx immediately after ServeNostr returns, so
-	//     a main-loop return reliably reaps this goroutine).
-	//   - recv close (client disconnect); closing msgQueue then drives the
-	//     main loop to return nil naturally.
+	// The drain goroutine's lifetime is bounded by drainCtx, a sub-ctx of
+	// the connection ctx. `defer drainCancel()` below runs on every main-
+	// loop return path (ctx cancel, msgQueue close / recv close, HandleMsg
+	// error, normal completion), so the drain goroutine is reliably reaped
+	// without depending on the caller to cancel the outer ctx. Recv close
+	// additionally closes msgQueue, which drives the main loop to return
+	// nil naturally.
+	drainCtx, drainCancel := context.WithCancel(ctx)
+	defer drainCancel()
 	msgQueue := make(chan *ClientMsg, simpleHandlerMsgQueueBuffer)
 	go func() {
 		defer close(msgQueue)
 		for {
 			select {
-			case <-ctx.Done():
+			case <-drainCtx.Done():
 				return
 			case msg, ok := <-recv:
 				if !ok {
 					return
 				}
 				select {
-				case <-ctx.Done():
+				case <-drainCtx.Done():
 					return
 				case msgQueue <- msg:
 				}

--- a/handler_test.go
+++ b/handler_test.go
@@ -328,21 +328,26 @@ func TestSimpleHandler_DrainsRecvWhileYieldBlocks(t *testing.T) {
 		synctest.Wait()
 
 		// Second message: with concurrent recv drain (the desired behaviour),
-		// HandleMsg is invoked a second time even though the first yield's
-		// send is still blocked. Push from a helper goroutine because if
-		// recv drain has stopped, the push itself blocks; make it ctx-aware
-		// so the final cancel cleanup reliably reaps the helper.
+		// the push below completes even though the first yield's send is
+		// still blocked. We do not observe HandleMsg being invoked a second
+		// time — the main loop is still parked on the first response's
+		// send — we only observe that recv itself keeps flowing. Push from
+		// a helper goroutine so that the test can distinguish "push
+		// succeeded" from "push is still blocked"; make it ctx-aware so the
+		// final cancel cleanup reliably reaps the helper.
+		delivered := make(chan struct{})
 		go func() {
 			select {
 			case recv <- &ClientMsg{Type: MsgTypeEvent}:
 			case <-ctx.Done():
 			}
+			close(delivered)
 		}()
 		synctest.Wait()
 
 		var drainStalled bool
 		select {
-		case <-handledMsgs:
+		case <-delivered:
 			t.Log("simpleHandler drained recv while yield was blocked (ideal)")
 		default:
 			drainStalled = true

--- a/handler_test.go
+++ b/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"iter"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -279,6 +280,84 @@ func TestSimpleHandler_MultipleMessages(t *testing.T) {
 	if len(send) != 6 { // 3 messages * 2 responses each
 		t.Errorf("expected 6 messages sent, got %d", len(send))
 	}
+}
+
+// TestSimpleHandler_DrainsRecvWhileYieldBlocks asserts that simpleHandler keeps
+// draining its recv channel while HandleMsg's response iterator is blocked on
+// sending. Without concurrent recv drain, a slow downstream (unread `send`)
+// stalls the handler itself and any upstream broadcaster (e.g. MergeHandler)
+// wedges on a full child-recv buffer — the "deadlock spring" shape observed at
+// production scale (see problem D, diary 2026-04-24).
+//
+// Today this test is EXPECTED TO FAIL on main: simpleHandler consumes
+// HandleMsg's iter.Seq synchronously on the same goroutine that reads recv, so
+// a blocked `send <- msg` pauses recv drain until the receiver unblocks.
+//
+// The structural fix (later commits in this branch) is to decouple recv drain
+// from response forwarding — e.g. a dedicated recv-drain goroutine feeding an
+// internal queue. Once that lands, this test should PASS as-written.
+func TestSimpleHandler_DrainsRecvWhileYieldBlocks(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		handledMsgs := make(chan *ClientMsg, 10)
+		mock := &mockSimpleHandlerBase{
+			handleMsgFunc: func(ctx context.Context, msg *ClientMsg) (iter.Seq[*ServerMsg], error) {
+				handledMsgs <- msg
+				return func(yield func(*ServerMsg) bool) {
+					yield(NewServerOKMsg("dummy", true, ""))
+				}, nil
+			},
+		}
+
+		handler := NewSimpleHandler(mock)
+		send := make(chan *ServerMsg) // unbuffered, intentionally never drained
+		recv := make(chan *ClientMsg) // unbuffered, so drain pauses are observable
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First message: handled, yields one response, then blocks on
+		// `send <- msg` because `send` has no reader. simpleHandler's
+		// goroutine is parked on that send from here on.
+		recv <- &ClientMsg{Type: MsgTypeEvent}
+		<-handledMsgs
+		synctest.Wait()
+
+		// Second message: with concurrent recv drain (the desired behaviour),
+		// HandleMsg is invoked a second time even though the first yield's
+		// send is still blocked. Push from a helper goroutine because if
+		// recv drain has stopped, the push itself blocks; make it ctx-aware
+		// so the final cancel cleanup reliably reaps the helper.
+		go func() {
+			select {
+			case recv <- &ClientMsg{Type: MsgTypeEvent}:
+			case <-ctx.Done():
+			}
+		}()
+		synctest.Wait()
+
+		var drainStalled bool
+		select {
+		case <-handledMsgs:
+			t.Log("simpleHandler drained recv while yield was blocked (ideal)")
+		default:
+			drainStalled = true
+		}
+
+		cancel()
+		synctest.Wait()
+		<-done
+
+		if drainStalled {
+			t.Fatal("simpleHandler stopped draining recv while HandleMsg's " +
+				"yield was blocked on send — this is the 'deadlock spring' " +
+				"shape that wedges MergeHandler childRecvs at production scale.")
+		}
+	})
 }
 
 func TestHandlerFunc(t *testing.T) {


### PR DESCRIPTION
## Background

Problem D, discovered on 2026-04-24 during post-PR-#77 effect verification
(diary 2026-04-24). PR #77 cut the 22-81 min wedge down to the 30s-exact
slow-REQ pattern (40-160× improvement), but a residual stall remained —
rooted one layer deeper, inside `simpleHandler` itself.

### Root cause

`simpleHandler.ServeNostr` consumed `HandleMsg`'s `iter.Seq` response on
the same goroutine that read `recv`. A blocked `send <- msg` in the
response yield loop stopped recv drain until the receiver unblocked.
Under `MergeHandler` (`childRecvs` cap 10) this manifested as the
"deadlock spring" shape:

```text
Storage yields → childSends (cap 10) fills → 11th yield blocks on send
  → simpleHandler stops reading recv
  → on next client msg, MergeHandler childRecvs fills
  → broadcastAll hits BroadcastTimeout (30s) → child retired
```

The 30s `BroadcastTimeout` is the escape hatch; without it the cycle is
effectively deadlock.

## Fix

Run a dedicated recv-drain goroutine that forwards `recv` into an internal
`msgQueue` (cap 10). The main loop consumes from `msgQueue`, invokes
`HandleMsg`, and forwards the `iter.Seq` response. A blocked yield no
longer stops recv drain.

**Invariant gained**: `HandleMsg`'s `iter.Seq` response may block on send,
but recv drain never fully stops.

## Verification

- New test `TestSimpleHandler_DrainsRecvWhileYieldBlocks`:
  - **FAIL** against `main` (RED verified by stashing the fix and running
    the tightened test against `main`'s `handler.go`)
  - **PASS** with the fix (GREEN)
- Full test suite with `-race`: all pass, no regressions
- Existing `handler_test.go` scenarios (normal flow, OnStart error,
  HandleMsg error, recv close, ctx cancel, nil/empty iter, multiple
  messages) all pass unchanged

## TDD history

- 🦆 `d3c0edb` test: add failing test for recv drain during yield block
- 🔬 `10347a8` test: tighten drain check to observe recv flow, not
  HandleMsg reentry (still RED but correctly scoped)
- 🐛 `e059598` fix: decouple recv drain from response forwarding in
  simpleHandler (GREEN)
- 📚 `af92550` docs(CLAUDE.md): document the iter.Seq recv-drain pattern

## Lifecycle notes

- The drain goroutine exits on either ctx cancel or recv close.
- `recv close` closes `msgQueue`, which drives the main loop to return nil
  naturally.
- The main loop exits on ctx cancel, `msgQueue` close, or `HandleMsg`
  error.
- All in-module `ServeNostr` callers (`Relay`, `NewSimpleMiddleware`'s
  downstream wrapper, `MergeHandler` per-child sub-ctx from PR #77) cancel
  ctx immediately after `ServeNostr` returns, which reliably reaps the
  drain goroutine on the error-return path — where the outer ctx is not
  yet cancelled at the moment the main loop returns.

## Buffer size (cap 10)

Only ≥1 is required for correctness (the invariant is "recv drain never
fully stops while yield is blocked"). 10 mirrors
`MergeHandler.childRecvs` so both layers share the same backpressure
budget. Slow send consumers are still backstopped by Relay's 10s write
timeout.

## Related

- Problem D diagnosis: `diary 2026-04-24`
- Diagnostic chain:
  - problem A (closure-local ctx bug) → partially addressed by Draft PR
    #76, effectively subsumed by PR #77's per-child ctx cancel
  - problem C (dead-retired child goroutine leak) → resolved by PR #77
  - **problem D (simpleHandler recv-drain stall under iter.Seq)** → this
    PR