### PR TITLE
feat: add KindAllowlistMiddlewareBase for restricting events to a well-known kind set

### DIFF
--- a/middleware_kind_allowlist.go
+++ b/middleware_kind_allowlist.go
@@ -8,7 +8,14 @@ import (
 // whose kind is NOT in kinds. This is useful for restricting a relay to a
 // well-known set of kinds (e.g., the kinds documented in the NIPs README).
 //
-// An empty allowlist rejects all events.
+// An empty allowlist rejects all events. Range-style kinds (e.g., NIP-90 Job
+// Request 5000-5999) are expanded into individual entries by the caller:
+//
+//	kinds := []int64{0, 1, 3}
+//	for k := int64(5000); k <= 5999; k++ {
+//		kinds = append(kinds, k)
+//	}
+//	mw := NewKindAllowlistMiddlewareBase(kinds)
 func NewKindAllowlistMiddlewareBase(kinds []int64) SimpleMiddlewareBase {
 	allowlist := make(map[int64]struct{}, len(kinds))
 	for _, k := range kinds {
@@ -39,7 +46,7 @@ func (m *kindAllowlistMiddleware) HandleClientMsg(ctx context.Context, msg *Clie
 	}
 
 	if _, allowed := m.allowlist[msg.Event.Kind]; !allowed {
-		logRejection(ctx, "kind_allowlist", "kind_not_allowed",
+		logRejection(ctx, "kind_allowlist", "kind_blocked",
 			"event_id", msg.Event.ID,
 			"kind", msg.Event.Kind,
 		)

--- a/middleware_kind_allowlist.go
+++ b/middleware_kind_allowlist.go
@@ -1,0 +1,55 @@
+package mocrelay
+
+import (
+	"context"
+)
+
+// NewKindAllowlistMiddlewareBase returns a middleware base that rejects events
+// whose kind is NOT in kinds. This is useful for restricting a relay to a
+// well-known set of kinds (e.g., the kinds documented in the NIPs README).
+//
+// An empty allowlist rejects all events.
+func NewKindAllowlistMiddlewareBase(kinds []int64) SimpleMiddlewareBase {
+	allowlist := make(map[int64]struct{}, len(kinds))
+	for _, k := range kinds {
+		allowlist[k] = struct{}{}
+	}
+	return &kindAllowlistMiddleware{allowlist: allowlist}
+}
+
+type kindAllowlistMiddleware struct {
+	allowlist map[int64]struct{}
+}
+
+func (m *kindAllowlistMiddleware) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
+	return ctx, nil, nil
+}
+
+func (m *kindAllowlistMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
+	return nil, nil
+}
+
+func (m *kindAllowlistMiddleware) HandleClientMsg(ctx context.Context, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	if msg.Type != MsgTypeEvent {
+		return msg, nil, nil
+	}
+
+	if msg.Event == nil {
+		return msg, nil, nil
+	}
+
+	if _, allowed := m.allowlist[msg.Event.Kind]; !allowed {
+		logRejection(ctx, "kind_allowlist", "kind_not_allowed",
+			"event_id", msg.Event.ID,
+			"kind", msg.Event.Kind,
+		)
+		resp := NewServerOKMsg(msg.Event.ID, false, "blocked: kind not allowed")
+		return nil, resp, nil
+	}
+
+	return msg, nil, nil
+}
+
+func (m *kindAllowlistMiddleware) HandleServerMsg(ctx context.Context, msg *ServerMsg) (*ServerMsg, error) {
+	return msg, nil
+}

--- a/middleware_kind_allowlist_test.go
+++ b/middleware_kind_allowlist_test.go
@@ -1,0 +1,282 @@
+package mocrelay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+)
+
+func TestKindAllowlistMiddleware_AllowAllowlisted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Allow only kind 1 (text note)
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase([]int64{1}))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send EVENT with kind 1 (allowed)
+		recv <- &ClientMsg{
+			Type: MsgTypeEvent,
+			Event: &Event{
+				ID:   "test-event-id",
+				Kind: 1,
+			},
+		}
+
+		synctest.Wait()
+
+		// Should receive OK true
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if !msg.Accepted {
+				t.Error("expected Accepted=true for kind 1")
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestKindAllowlistMiddleware_RejectNonAllowlisted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Allow only kinds 0, 1, 3 (well-known basics)
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase([]int64{0, 1, 3}))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send EVENT with kind 999 (not in allowlist)
+		recv <- &ClientMsg{
+			Type: MsgTypeEvent,
+			Event: &Event{
+				ID:   "test-event-id",
+				Kind: 999,
+			},
+		}
+
+		synctest.Wait()
+
+		// Should receive OK false
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if msg.Accepted {
+				t.Error("expected Accepted=false for kind 999")
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestKindAllowlistMiddleware_RejectDM(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Allow only kinds 0, 1, 3 (DM kinds excluded)
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase([]int64{0, 1, 3}))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send EVENT with kind 1059 (Gift Wrap, should be blocked)
+		recv <- &ClientMsg{
+			Type: MsgTypeEvent,
+			Event: &Event{
+				ID:   "test-event-id",
+				Kind: 1059,
+			},
+		}
+
+		synctest.Wait()
+
+		// Should receive OK false
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if msg.Accepted {
+				t.Error("expected Accepted=false for kind 1059 (Gift Wrap)")
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestKindAllowlistMiddleware_EmptyAllowlist(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Empty allowlist - all kinds rejected
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase([]int64{}))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send EVENT with kind 1 (should be rejected with empty allowlist)
+		recv <- &ClientMsg{
+			Type: MsgTypeEvent,
+			Event: &Event{
+				ID:   "test-event-id",
+				Kind: 1,
+			},
+		}
+
+		synctest.Wait()
+
+		// Should receive OK false
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if msg.Accepted {
+				t.Error("expected Accepted=false with empty allowlist")
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestKindAllowlistMiddleware_PassthroughNonEvent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Empty allowlist (would block all events)
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase([]int64{}))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send REQ (not EVENT, should pass through)
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{}},
+		}
+
+		synctest.Wait()
+
+		// Should receive EOSE from NopHandler
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeEOSE {
+				t.Errorf("expected EOSE, got %v", msg.Type)
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestKindAllowlistMiddleware_RangeAllowed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Allow Job Request range (5000-5999, expanded)
+		var kinds []int64
+		for k := int64(5000); k <= 5999; k++ {
+			kinds = append(kinds, k)
+		}
+		middleware := NewSimpleMiddleware(NewKindAllowlistMiddlewareBase(kinds))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Send EVENT with kind 5500 (in range)
+		recv <- &ClientMsg{
+			Type: MsgTypeEvent,
+			Event: &Event{
+				ID:   "test-event-id",
+				Kind: 5500,
+			},
+		}
+
+		synctest.Wait()
+
+		// Should receive OK true
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if !msg.Accepted {
+				t.Error("expected Accepted=true for kind 5500 in range")
+			}
+		default:
+			t.Error("expected message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}


### PR DESCRIPTION
## Summary

- Add `NewKindAllowlistMiddlewareBase` as a counterpart to the existing `NewKindDenylistMiddlewareBase`. Only events whose kind is in the allowlist are accepted; everything else is rejected with `blocked: kind not allowed`.
- Useful for relays that want to limit ingress to a curated, well-known kind set (e.g., the kinds documented in the NIPs README) and refuse every other kind by default — including kinds from new NIPs the operator has not yet vetted.
- Empty allowlist rejects all events. Range-style kinds (e.g., `5000-5999` Job Request) are expanded into individual entries by the caller; map lookup is O(1) regardless of size.
- Rejection log shape (`kind_allowlist` / `kind_not_allowed`) and rejection message follow the existing denylist conventions so log consumers can filter on a consistent vocabulary.

## Why

moctane-mocrelay wants to switch from a small DM-only denylist (Japanese telecommunications-law compliance) to an explicit allowlist of well-known kinds. The denylist approach cannot keep up with newly added kinds, so an allowlist primitive belongs in the library — symmetric to what is already there.

## Test plan

- [x] `go test ./...` — all existing tests still pass; six new test cases mirror the denylist test suite (`allow / reject / DM-rejected / empty allowlist / non-EVENT passthrough / 1000-entry range expansion`)
- [x] `go vet ./...`
- [ ] CI green

🌸 Generated with [Claude Code](https://claude.com/claude-code)