### PR TITLE
feat: per-connection rate limit middlewares for EVENT / REQ / COUNT / AUTH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -783,15 +783,18 @@ handler dispatch).
 | `CountRateLimit` ✅ | per-connection COUNT rate limit | CLOSED `"rate-limited: too many counts"` |
 | `AuthRateLimit` ✅ | per-connection AUTH rate limit | OK `accepted=false` `"rate-limited: too many auth attempts"` |
 
-All four share the same Options shape (just with the type-specific
-name) and the same internal `tokenBucket` helper:
+All four share the same constructor shape and the same internal
+`tokenBucket` helper. Both arguments are required (no defaults), so the
+constructors take them positionally without an Options struct -- the
+same shape as `NewMaxLimitMiddlewareBase`:
 
 ```go
-type {Type}RateLimitMiddlewareOptions struct {
-    Rate  float64 // tokens per second; positive
-    Burst float64 // max burst, bucket starts full at OnStart; positive
-}
+New{Type}RateLimitMiddlewareBase(rate float64, burst int) SimpleMiddlewareBase
 ```
+
+`rate` is tokens per second (must be > 0). `burst` is the maximum
+number of messages a connection may submit in a tight window (must be
+>= 1; the bucket starts full at OnStart).
 
 **Per-connection isolation**: each middleware owns its own bucket
 scoped per connection (created in `OnStart`, stored in the request

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -770,6 +770,46 @@ This is mocrelay's main value proposition.
 | `ProtectedEventsMiddleware` ✅ | NIP-70 | Prevent republishing `["-"]` tagged events (requires NIP-42 AUTH) |
 | `CompositeStorage` ✅ | NIP-50 | Full-text search via Bleve with CJK support |
 
+#### Operational Hardening (NIP-independent) ✅
+
+These middlewares are not tied to any NIP. They throttle abusive client
+behavior at the application layer (after parse, before storage /
+handler dispatch).
+
+| Middleware | Purpose | Reject |
+|------------|---------|--------|
+| `EventRateLimit` ✅ | per-connection EVENT rate limit | OK `accepted=false` `"rate-limited: too many events"` |
+| `ReqRateLimit` ✅ | per-connection REQ rate limit | CLOSED `"rate-limited: too many subscriptions"` |
+| `CountRateLimit` ✅ | per-connection COUNT rate limit | CLOSED `"rate-limited: too many counts"` |
+| `AuthRateLimit` ✅ | per-connection AUTH rate limit | OK `accepted=false` `"rate-limited: too many auth attempts"` |
+
+All four share the same Options shape (just with the type-specific
+name) and the same internal `tokenBucket` helper:
+
+```go
+type {Type}RateLimitMiddlewareOptions struct {
+    Rate  float64 // tokens per second; positive
+    Burst float64 // max burst, bucket starts full at OnStart; positive
+}
+```
+
+**Per-connection isolation**: each middleware owns its own bucket
+scoped per connection (created in `OnStart`, stored in the request
+context). The middleware instance itself is shared across connections;
+only the bucket state is per-connection. Memory cost is therefore
+`O(connections × middlewares_enabled)`.
+
+**Composition**: enable only the types you need; counters never
+interact across types. A typical hardened relay enables all four with
+deliberately different limits — e.g. `Rate=10, Burst=20` for EVENT but
+`Rate=0.1, Burst=3` for AUTH to throttle credential stuffing.
+
+**Out of scope**: per-IP / per-pubkey / global limits, and limiting
+the total WebSocket message rate before parse. Those belong in a
+different layer (the WebSocket readLoop or an external reverse proxy)
+and would couple to identity / network topology that the middleware
+layer cannot see.
+
 #### Future NIP Implementation Priority
 
 **Special features (as needed)**:

--- a/middleware_auth_rate_limit.go
+++ b/middleware_auth_rate_limit.go
@@ -5,23 +5,15 @@ import (
 	"time"
 )
 
-// AuthRateLimitMiddlewareOptions configures the middleware returned by
-// [NewAuthRateLimitMiddlewareBase]. Both fields are required; zero or
-// negative values cause the constructor to panic.
-type AuthRateLimitMiddlewareOptions struct {
-	// Rate is the long-term sustained rate of AUTH (NIP-42) messages
-	// allowed per connection, in AUTHs per second.
-	Rate float64
-
-	// Burst is the maximum number of AUTH messages a connection may
-	// submit in a tight window before rate-limiting kicks in. The bucket
-	// starts full at connection start.
-	Burst float64
-}
-
 // NewAuthRateLimitMiddlewareBase returns a middleware base that rate-limits
 // incoming AUTH (NIP-42) messages on a per-connection basis using a token
 // bucket.
+//
+// rate is the long-term sustained rate of AUTH messages allowed per
+// connection, in AUTHs per second; must be positive.
+// burst is the maximum number of AUTH messages a connection may submit
+// in a tight window before rate-limiting kicks in. The bucket starts
+// full at connection start; must be positive.
 //
 // When the bucket is empty, the offending AUTH is dropped and a
 // `["OK", <event_id>, false, "rate-limited: too many auth attempts"]` is
@@ -33,32 +25,29 @@ type AuthRateLimitMiddlewareOptions struct {
 // limit those independently.
 //
 // Use this middleware to defend against AUTH challenge-response brute
-// force; a typical setting is a low Rate (e.g. 0.1 = one attempt every
-// 10 seconds long-term) with a small Burst (e.g. 3) so legitimate
+// force; a typical setting is a low rate (e.g. 0.1 = one attempt every
+// 10 seconds long-term) with a small burst (e.g. 3) so legitimate
 // reconnects still work but credential stuffing is throttled.
 //
 // Each connection gets its own token bucket via OnStart + context.
 //
-// Panics if opts is nil or if Rate / Burst is not positive.
-func NewAuthRateLimitMiddlewareBase(opts *AuthRateLimitMiddlewareOptions) SimpleMiddlewareBase {
-	if opts == nil {
-		panic("opts must not be nil")
+// Panics if rate <= 0 or burst < 1.
+func NewAuthRateLimitMiddlewareBase(rate float64, burst int) SimpleMiddlewareBase {
+	if rate <= 0 {
+		panic("rate must be positive")
 	}
-	if opts.Rate <= 0 {
-		panic("Rate must be positive")
-	}
-	if opts.Burst <= 0 {
-		panic("Burst must be positive")
+	if burst < 1 {
+		panic("burst must be positive")
 	}
 	return &authRateLimitMiddleware{
-		rate:  opts.Rate,
-		burst: opts.Burst,
+		rate:  rate,
+		burst: burst,
 	}
 }
 
 type authRateLimitMiddleware struct {
 	rate  float64
-	burst float64
+	burst int
 }
 
 type authRateLimitCtxKey struct{}

--- a/middleware_auth_rate_limit.go
+++ b/middleware_auth_rate_limit.go
@@ -1,0 +1,98 @@
+package mocrelay
+
+import (
+	"context"
+	"time"
+)
+
+// AuthRateLimitMiddlewareOptions configures the middleware returned by
+// [NewAuthRateLimitMiddlewareBase]. Both fields are required; zero or
+// negative values cause the constructor to panic.
+type AuthRateLimitMiddlewareOptions struct {
+	// Rate is the long-term sustained rate of AUTH (NIP-42) messages
+	// allowed per connection, in AUTHs per second.
+	Rate float64
+
+	// Burst is the maximum number of AUTH messages a connection may
+	// submit in a tight window before rate-limiting kicks in. The bucket
+	// starts full at connection start.
+	Burst float64
+}
+
+// NewAuthRateLimitMiddlewareBase returns a middleware base that rate-limits
+// incoming AUTH (NIP-42) messages on a per-connection basis using a token
+// bucket.
+//
+// When the bucket is empty, the offending AUTH is dropped and a
+// `["OK", <event_id>, false, "rate-limited: too many auth attempts"]` is
+// sent to the client. NIP-42 specifies AUTH responses are OK messages, so
+// the response shape matches a successful AUTH except for accepted=false.
+//
+// EVENT / REQ / CLOSE / COUNT messages pass through untouched -- compose
+// with the matching per-type middleware (Event/Req/Count) if you need to
+// limit those independently.
+//
+// Use this middleware to defend against AUTH challenge-response brute
+// force; a typical setting is a low Rate (e.g. 0.1 = one attempt every
+// 10 seconds long-term) with a small Burst (e.g. 3) so legitimate
+// reconnects still work but credential stuffing is throttled.
+//
+// Each connection gets its own token bucket via OnStart + context.
+//
+// Panics if opts is nil or if Rate / Burst is not positive.
+func NewAuthRateLimitMiddlewareBase(opts *AuthRateLimitMiddlewareOptions) SimpleMiddlewareBase {
+	if opts == nil {
+		panic("opts must not be nil")
+	}
+	if opts.Rate <= 0 {
+		panic("Rate must be positive")
+	}
+	if opts.Burst <= 0 {
+		panic("Burst must be positive")
+	}
+	return &authRateLimitMiddleware{
+		rate:  opts.Rate,
+		burst: opts.Burst,
+	}
+}
+
+type authRateLimitMiddleware struct {
+	rate  float64
+	burst float64
+}
+
+type authRateLimitCtxKey struct{}
+
+func (m *authRateLimitMiddleware) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
+	tb := newTokenBucket(m.rate, m.burst, time.Now())
+	ctx = context.WithValue(ctx, authRateLimitCtxKey{}, tb)
+	return ctx, nil, nil
+}
+
+func (m *authRateLimitMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
+	return nil, nil
+}
+
+func (m *authRateLimitMiddleware) HandleClientMsg(ctx context.Context, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	if msg.Type != MsgTypeAuth {
+		return msg, nil, nil
+	}
+
+	tb := ctx.Value(authRateLimitCtxKey{}).(*tokenBucket)
+	if tb.allow(time.Now()) {
+		return msg, nil, nil
+	}
+
+	eventID := ""
+	if msg.Event != nil {
+		eventID = msg.Event.ID
+	}
+	logRejection(ctx, "auth_rate_limit", "rate_limited",
+		"event_id", eventID,
+	)
+	return nil, NewServerOKMsg(eventID, false, "rate-limited: too many auth attempts"), nil
+}
+
+func (m *authRateLimitMiddleware) HandleServerMsg(ctx context.Context, msg *ServerMsg) (*ServerMsg, error) {
+	return msg, nil
+}

--- a/middleware_auth_rate_limit_test.go
+++ b/middleware_auth_rate_limit_test.go
@@ -51,9 +51,7 @@ func sendAuthDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg,
 
 func TestAuthRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
-			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
-		))
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(1, 3))
 		handler := middleware(authEchoHandler())
 
 		recv := make(chan *ClientMsg)
@@ -85,9 +83,7 @@ func TestAuthRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 
 func TestAuthRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
-			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
-		))
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(1, 2))
 		handler := middleware(authEchoHandler())
 
 		recv := make(chan *ClientMsg)
@@ -134,9 +130,7 @@ func TestAuthRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 
 func TestAuthRateLimitMiddleware_RejectMissingEvent(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
-			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(1, 1))
 		handler := middleware(authEchoHandler())
 
 		recv := make(chan *ClientMsg)
@@ -185,9 +179,7 @@ func TestAuthRateLimitMiddleware_RejectMissingEvent(t *testing.T) {
 
 func TestAuthRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
-			&AuthRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(2, 1))
 		handler := middleware(authEchoHandler())
 
 		recv := make(chan *ClientMsg)
@@ -211,6 +203,7 @@ func TestAuthRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 			t.Error("expected second AUTH rate-limited")
 		}
 
+		// (synctest.Test bubble: time.Sleep advances the fake clock, no real wait.)
 		time.Sleep(1 * time.Second)
 
 		third := sendAuthDrain(t, recv, send, "a")
@@ -230,9 +223,7 @@ func TestAuthRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 
 func TestAuthRateLimitMiddleware_NonAuthPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
-			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(1, 1))
 		// Use NopHandler here because we want EVENT/REQ pass-through
 		// behavior, not AUTH. Drain the AUTH bucket first via the echo
 		// handler test above; here just verify EVENT passes through with
@@ -274,9 +265,7 @@ func TestAuthRateLimitMiddleware_NonAuthPassThrough(t *testing.T) {
 }
 
 func TestAuthRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
-	base := NewAuthRateLimitMiddlewareBase(
-		&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-	)
+	base := NewAuthRateLimitMiddlewareBase(1, 1)
 
 	runConn := func(t *testing.T) *ServerMsg {
 		var got *ServerMsg
@@ -307,29 +296,38 @@ func TestAuthRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
 	}
 }
 
-func TestNewAuthRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil opts")
-		}
-	}()
-	NewAuthRateLimitMiddlewareBase(nil)
-}
-
 func TestNewAuthRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Rate=0")
+			t.Fatal("expected panic for rate=0")
 		}
 	}()
-	NewAuthRateLimitMiddlewareBase(&AuthRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+	NewAuthRateLimitMiddlewareBase(0, 1)
+}
+
+func TestNewAuthRateLimitMiddlewareBase_PanicOnNegativeRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative rate")
+		}
+	}()
+	NewAuthRateLimitMiddlewareBase(-1, 1)
 }
 
 func TestNewAuthRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Burst=0")
+			t.Fatal("expected panic for burst=0")
 		}
 	}()
-	NewAuthRateLimitMiddlewareBase(&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+	NewAuthRateLimitMiddlewareBase(1, 0)
+}
+
+func TestNewAuthRateLimitMiddlewareBase_PanicOnNegativeBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative burst")
+		}
+	}()
+	NewAuthRateLimitMiddlewareBase(1, -1)
 }

--- a/middleware_auth_rate_limit_test.go
+++ b/middleware_auth_rate_limit_test.go
@@ -1,0 +1,335 @@
+package mocrelay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// authEchoHandler is a test-only handler that ACKs every AUTH message it
+// receives with an OK. NopHandler does not handle AUTH, so we need this
+// to verify that AUTH messages pass through the rate-limit middleware.
+func authEchoHandler() Handler {
+	return HandlerFunc(func(ctx context.Context, send chan<- *ServerMsg, recv <-chan *ClientMsg) error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case msg, ok := <-recv:
+				if !ok {
+					return nil
+				}
+				if msg.Type == MsgTypeAuth && msg.Event != nil {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case send <- NewServerOKMsg(msg.Event.ID, true, ""):
+					}
+				}
+			}
+		}
+	})
+}
+
+// helper: send one AUTH, wait, drain a single message and return it.
+func sendAuthDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg, eventID string) *ServerMsg {
+	t.Helper()
+	recv <- &ClientMsg{
+		Type:  MsgTypeAuth,
+		Event: &Event{ID: eventID, Kind: 22242},
+	}
+	synctest.Wait()
+	select {
+	case msg := <-send:
+		return msg
+	default:
+		t.Fatal("expected message but got none")
+		return nil
+	}
+}
+
+func TestAuthRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
+			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
+		))
+		handler := middleware(authEchoHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Burst=3 -> three AUTHs reach the echo handler -> OK true.
+		for i := range 3 {
+			msg := sendAuthDrain(t, recv, send, "auth-ev")
+			if msg.Type != MsgTypeOK {
+				t.Errorf("at %d: expected OK, got %v", i, msg.Type)
+			}
+			if !msg.Accepted {
+				t.Errorf("at %d: expected Accepted=true", i)
+			}
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestAuthRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
+			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
+		))
+		handler := middleware(authEchoHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First two: accepted (passes through to echo handler)
+		for i := range 2 {
+			msg := sendAuthDrain(t, recv, send, "auth-ev")
+			if msg.Type != MsgTypeOK {
+				t.Errorf("at %d: expected OK, got %v", i, msg.Type)
+			}
+			if !msg.Accepted {
+				t.Errorf("at %d: expected Accepted=true", i)
+			}
+		}
+
+		// Third: rate-limited (OK accepted=false from the middleware)
+		msg := sendAuthDrain(t, recv, send, "auth-ev-3")
+		if msg.Type != MsgTypeOK {
+			t.Errorf("expected OK, got %v", msg.Type)
+		}
+		if msg.Accepted {
+			t.Error("expected Accepted=false")
+		}
+		if msg.Message != "rate-limited: too many auth attempts" {
+			t.Errorf("unexpected reason: %q", msg.Message)
+		}
+		if msg.EventID != "auth-ev-3" {
+			t.Errorf("expected EventID=%q in OK, got %q", "auth-ev-3", msg.EventID)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestAuthRateLimitMiddleware_RejectMissingEvent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
+			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+		))
+		handler := middleware(authEchoHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Drain bucket
+		first := sendAuthDrain(t, recv, send, "auth-ok")
+		if !first.Accepted {
+			t.Fatal("expected first AUTH accepted")
+		}
+
+		// Second AUTH with nil Event must still be rejected with rate-limit
+		// (no panic, empty EventID in the OK reply)
+		recv <- &ClientMsg{
+			Type:  MsgTypeAuth,
+			Event: nil,
+		}
+		synctest.Wait()
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK, got %v", msg.Type)
+			}
+			if msg.Accepted {
+				t.Error("expected Accepted=false")
+			}
+			if msg.EventID != "" {
+				t.Errorf("expected empty EventID for nil Event, got %q", msg.EventID)
+			}
+		default:
+			t.Fatal("expected response")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestAuthRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
+			&AuthRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
+		))
+		handler := middleware(authEchoHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		first := sendAuthDrain(t, recv, send, "a")
+		if !first.Accepted {
+			t.Error("expected first AUTH accepted")
+		}
+
+		second := sendAuthDrain(t, recv, send, "a")
+		if second.Accepted {
+			t.Error("expected second AUTH rate-limited")
+		}
+
+		time.Sleep(1 * time.Second)
+
+		third := sendAuthDrain(t, recv, send, "a")
+		if !third.Accepted {
+			t.Error("expected third AUTH accepted after refill")
+		}
+
+		fourth := sendAuthDrain(t, recv, send, "a")
+		if fourth.Accepted {
+			t.Error("expected fourth AUTH rate-limited (burst capped)")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestAuthRateLimitMiddleware_NonAuthPassThrough(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewAuthRateLimitMiddlewareBase(
+			&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+		))
+		// Use NopHandler here because we want EVENT/REQ pass-through
+		// behavior, not AUTH. Drain the AUTH bucket first via the echo
+		// handler test above; here just verify EVENT passes through with
+		// the AUTH bucket fully empty.
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// EVENT must pass through regardless of AUTH bucket state
+		recv <- &ClientMsg{
+			Type:  MsgTypeEvent,
+			Event: &Event{ID: "ev", Content: "x"},
+		}
+		synctest.Wait()
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK for EVENT pass-through, got %v", msg.Type)
+			}
+			if !msg.Accepted {
+				t.Error("expected EVENT accepted")
+			}
+		default:
+			t.Fatal("expected EVENT response")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestAuthRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
+	base := NewAuthRateLimitMiddlewareBase(
+		&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+	)
+
+	runConn := func(t *testing.T) *ServerMsg {
+		var got *ServerMsg
+		synctest.Test(t, func(t *testing.T) {
+			handler := NewSimpleMiddleware(base)(authEchoHandler())
+			recv := make(chan *ClientMsg)
+			send := make(chan *ServerMsg, 4)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error)
+			go func() { done <- handler.ServeNostr(ctx, send, recv) }()
+
+			got = sendAuthDrain(t, recv, send, "a")
+
+			cancel()
+			<-done
+		})
+		return got
+	}
+
+	first := runConn(t)
+	if !first.Accepted {
+		t.Error("conn1: expected first AUTH accepted")
+	}
+	second := runConn(t)
+	if !second.Accepted {
+		t.Error("conn2: expected first AUTH accepted (per-connection bucket)")
+	}
+}
+
+func TestNewAuthRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil opts")
+		}
+	}()
+	NewAuthRateLimitMiddlewareBase(nil)
+}
+
+func TestNewAuthRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Rate=0")
+		}
+	}()
+	NewAuthRateLimitMiddlewareBase(&AuthRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+}
+
+func TestNewAuthRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Burst=0")
+		}
+	}()
+	NewAuthRateLimitMiddlewareBase(&AuthRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+}

--- a/middleware_count_rate_limit.go
+++ b/middleware_count_rate_limit.go
@@ -1,0 +1,89 @@
+package mocrelay
+
+import (
+	"context"
+	"time"
+)
+
+// CountRateLimitMiddlewareOptions configures the middleware returned by
+// [NewCountRateLimitMiddlewareBase]. Both fields are required; zero or
+// negative values cause the constructor to panic.
+type CountRateLimitMiddlewareOptions struct {
+	// Rate is the long-term sustained rate of COUNT (NIP-45) messages
+	// allowed per connection, in COUNTs per second.
+	Rate float64
+
+	// Burst is the maximum number of COUNT messages a connection may
+	// submit in a tight window before rate-limiting kicks in. The bucket
+	// starts full at connection start.
+	Burst float64
+}
+
+// NewCountRateLimitMiddlewareBase returns a middleware base that rate-limits
+// incoming COUNT (NIP-45) messages on a per-connection basis using a token
+// bucket.
+//
+// When the bucket is empty, the offending COUNT is dropped and a
+// `["CLOSED", <sub_id>, "rate-limited: too many counts"]` is sent to the
+// client. EVENT / REQ / CLOSE / AUTH messages pass through untouched --
+// compose with the matching per-type middleware (Event/Req/Auth) if you
+// need to limit those independently.
+//
+// COUNT can be expensive to compute (it scans the same indexes a REQ
+// would but cannot stream early), so a tighter rate than REQ is often
+// appropriate. Each connection gets its own token bucket via OnStart +
+// context.
+//
+// Panics if opts is nil or if Rate / Burst is not positive.
+func NewCountRateLimitMiddlewareBase(opts *CountRateLimitMiddlewareOptions) SimpleMiddlewareBase {
+	if opts == nil {
+		panic("opts must not be nil")
+	}
+	if opts.Rate <= 0 {
+		panic("Rate must be positive")
+	}
+	if opts.Burst <= 0 {
+		panic("Burst must be positive")
+	}
+	return &countRateLimitMiddleware{
+		rate:  opts.Rate,
+		burst: opts.Burst,
+	}
+}
+
+type countRateLimitMiddleware struct {
+	rate  float64
+	burst float64
+}
+
+type countRateLimitCtxKey struct{}
+
+func (m *countRateLimitMiddleware) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
+	tb := newTokenBucket(m.rate, m.burst, time.Now())
+	ctx = context.WithValue(ctx, countRateLimitCtxKey{}, tb)
+	return ctx, nil, nil
+}
+
+func (m *countRateLimitMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
+	return nil, nil
+}
+
+func (m *countRateLimitMiddleware) HandleClientMsg(ctx context.Context, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	if msg.Type != MsgTypeCount {
+		return msg, nil, nil
+	}
+
+	tb := ctx.Value(countRateLimitCtxKey{}).(*tokenBucket)
+	if tb.allow(time.Now()) {
+		return msg, nil, nil
+	}
+
+	logRejection(ctx, "count_rate_limit", "rate_limited",
+		"sub_id", msg.SubscriptionID,
+	)
+	return nil, NewServerClosedMsg(msg.SubscriptionID, "rate-limited: too many counts"), nil
+}
+
+func (m *countRateLimitMiddleware) HandleServerMsg(ctx context.Context, msg *ServerMsg) (*ServerMsg, error) {
+	return msg, nil
+}

--- a/middleware_count_rate_limit.go
+++ b/middleware_count_rate_limit.go
@@ -5,23 +5,15 @@ import (
 	"time"
 )
 
-// CountRateLimitMiddlewareOptions configures the middleware returned by
-// [NewCountRateLimitMiddlewareBase]. Both fields are required; zero or
-// negative values cause the constructor to panic.
-type CountRateLimitMiddlewareOptions struct {
-	// Rate is the long-term sustained rate of COUNT (NIP-45) messages
-	// allowed per connection, in COUNTs per second.
-	Rate float64
-
-	// Burst is the maximum number of COUNT messages a connection may
-	// submit in a tight window before rate-limiting kicks in. The bucket
-	// starts full at connection start.
-	Burst float64
-}
-
 // NewCountRateLimitMiddlewareBase returns a middleware base that rate-limits
 // incoming COUNT (NIP-45) messages on a per-connection basis using a token
 // bucket.
+//
+// rate is the long-term sustained rate of COUNT messages allowed per
+// connection, in COUNTs per second; must be positive.
+// burst is the maximum number of COUNT messages a connection may submit
+// in a tight window before rate-limiting kicks in. The bucket starts
+// full at connection start; must be positive.
 //
 // When the bucket is empty, the offending COUNT is dropped and a
 // `["CLOSED", <sub_id>, "rate-limited: too many counts"]` is sent to the
@@ -34,26 +26,23 @@ type CountRateLimitMiddlewareOptions struct {
 // appropriate. Each connection gets its own token bucket via OnStart +
 // context.
 //
-// Panics if opts is nil or if Rate / Burst is not positive.
-func NewCountRateLimitMiddlewareBase(opts *CountRateLimitMiddlewareOptions) SimpleMiddlewareBase {
-	if opts == nil {
-		panic("opts must not be nil")
+// Panics if rate <= 0 or burst < 1.
+func NewCountRateLimitMiddlewareBase(rate float64, burst int) SimpleMiddlewareBase {
+	if rate <= 0 {
+		panic("rate must be positive")
 	}
-	if opts.Rate <= 0 {
-		panic("Rate must be positive")
-	}
-	if opts.Burst <= 0 {
-		panic("Burst must be positive")
+	if burst < 1 {
+		panic("burst must be positive")
 	}
 	return &countRateLimitMiddleware{
-		rate:  opts.Rate,
-		burst: opts.Burst,
+		rate:  rate,
+		burst: burst,
 	}
 }
 
 type countRateLimitMiddleware struct {
 	rate  float64
-	burst float64
+	burst int
 }
 
 type countRateLimitCtxKey struct{}

--- a/middleware_count_rate_limit_test.go
+++ b/middleware_count_rate_limit_test.go
@@ -1,0 +1,254 @@
+package mocrelay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// helper: send one COUNT, wait, drain a single message and return it.
+func sendCountDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg, subID string) *ServerMsg {
+	t.Helper()
+	limit := int64(0)
+	recv <- &ClientMsg{
+		Type:           MsgTypeCount,
+		SubscriptionID: subID,
+		Filters:        []*ReqFilter{{Limit: &limit}},
+	}
+	synctest.Wait()
+	select {
+	case msg := <-send:
+		return msg
+	default:
+		t.Fatal("expected message but got none")
+		return nil
+	}
+}
+
+func TestCountRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
+			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Burst=3 -> three COUNTs reach NopHandler -> COUNT response with count=0.
+		for i := range 3 {
+			msg := sendCountDrain(t, recv, send, "sub")
+			if msg.Type != MsgTypeCount {
+				t.Errorf("at %d: expected COUNT, got %v", i, msg.Type)
+			}
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestCountRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
+			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First two: COUNT response from NopHandler
+		for i := range 2 {
+			msg := sendCountDrain(t, recv, send, "sub")
+			if msg.Type != MsgTypeCount {
+				t.Errorf("at %d: expected COUNT, got %v", i, msg.Type)
+			}
+		}
+
+		// Third: CLOSED with rate-limited prefix
+		msg := sendCountDrain(t, recv, send, "sub-3")
+		if msg.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED, got %v", msg.Type)
+		}
+		if msg.Message != "rate-limited: too many counts" {
+			t.Errorf("unexpected reason: %q", msg.Message)
+		}
+		if msg.SubscriptionID != "sub-3" {
+			t.Errorf("expected sub_id=%q, got %q", "sub-3", msg.SubscriptionID)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestCountRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
+			&CountRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		first := sendCountDrain(t, recv, send, "s")
+		if first.Type != MsgTypeCount {
+			t.Errorf("expected COUNT, got %v", first.Type)
+		}
+
+		second := sendCountDrain(t, recv, send, "s")
+		if second.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED for rate-limited COUNT, got %v", second.Type)
+		}
+
+		// Wait 1 second: bucket refilled (capped at burst=1)
+		time.Sleep(1 * time.Second)
+
+		third := sendCountDrain(t, recv, send, "s")
+		if third.Type != MsgTypeCount {
+			t.Errorf("expected COUNT after refill, got %v", third.Type)
+		}
+
+		fourth := sendCountDrain(t, recv, send, "s")
+		if fourth.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED (burst capped), got %v", fourth.Type)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestCountRateLimitMiddleware_NonCountPassThrough(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
+			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Drain the COUNT bucket
+		first := sendCountDrain(t, recv, send, "s1")
+		if first.Type != MsgTypeCount {
+			t.Fatalf("expected COUNT, got %v", first.Type)
+		}
+
+		// REQ must pass through (COUNT bucket empty does NOT affect REQ)
+		limit := int64(0)
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{Limit: &limit}},
+		}
+		synctest.Wait()
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeEOSE {
+				t.Errorf("expected EOSE for REQ pass-through, got %v", msg.Type)
+			}
+		default:
+			t.Fatal("expected REQ response")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestCountRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
+	base := NewCountRateLimitMiddlewareBase(
+		&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+	)
+
+	runConn := func(t *testing.T) *ServerMsg {
+		var got *ServerMsg
+		synctest.Test(t, func(t *testing.T) {
+			handler := NewSimpleMiddleware(base)(NewNopHandler())
+			recv := make(chan *ClientMsg)
+			send := make(chan *ServerMsg, 4)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error)
+			go func() { done <- handler.ServeNostr(ctx, send, recv) }()
+
+			got = sendCountDrain(t, recv, send, "s")
+
+			cancel()
+			<-done
+		})
+		return got
+	}
+
+	first := runConn(t)
+	if first.Type != MsgTypeCount {
+		t.Errorf("conn1: expected COUNT, got %v", first.Type)
+	}
+	second := runConn(t)
+	if second.Type != MsgTypeCount {
+		t.Errorf("conn2: expected COUNT (per-connection bucket), got %v", second.Type)
+	}
+}
+
+func TestNewCountRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil opts")
+		}
+	}()
+	NewCountRateLimitMiddlewareBase(nil)
+}
+
+func TestNewCountRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Rate=0")
+		}
+	}()
+	NewCountRateLimitMiddlewareBase(&CountRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+}
+
+func TestNewCountRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Burst=0")
+		}
+	}()
+	NewCountRateLimitMiddlewareBase(&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+}

--- a/middleware_count_rate_limit_test.go
+++ b/middleware_count_rate_limit_test.go
@@ -28,9 +28,7 @@ func sendCountDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg
 
 func TestCountRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
-			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
-		))
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(1, 3))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -59,9 +57,7 @@ func TestCountRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 
 func TestCountRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
-			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
-		))
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(1, 2))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -102,9 +98,7 @@ func TestCountRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 
 func TestCountRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
-			&CountRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(2, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -129,6 +123,7 @@ func TestCountRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 		}
 
 		// Wait 1 second: bucket refilled (capped at burst=1)
+		// (synctest.Test bubble: time.Sleep advances the fake clock, no real wait.)
 		time.Sleep(1 * time.Second)
 
 		third := sendCountDrain(t, recv, send, "s")
@@ -148,9 +143,7 @@ func TestCountRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 
 func TestCountRateLimitMiddleware_NonCountPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(
-			&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewCountRateLimitMiddlewareBase(1, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -193,9 +186,7 @@ func TestCountRateLimitMiddleware_NonCountPassThrough(t *testing.T) {
 }
 
 func TestCountRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
-	base := NewCountRateLimitMiddlewareBase(
-		&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-	)
+	base := NewCountRateLimitMiddlewareBase(1, 1)
 
 	runConn := func(t *testing.T) *ServerMsg {
 		var got *ServerMsg
@@ -226,29 +217,38 @@ func TestCountRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
 	}
 }
 
-func TestNewCountRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil opts")
-		}
-	}()
-	NewCountRateLimitMiddlewareBase(nil)
-}
-
 func TestNewCountRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Rate=0")
+			t.Fatal("expected panic for rate=0")
 		}
 	}()
-	NewCountRateLimitMiddlewareBase(&CountRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+	NewCountRateLimitMiddlewareBase(0, 1)
+}
+
+func TestNewCountRateLimitMiddlewareBase_PanicOnNegativeRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative rate")
+		}
+	}()
+	NewCountRateLimitMiddlewareBase(-1, 1)
 }
 
 func TestNewCountRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Burst=0")
+			t.Fatal("expected panic for burst=0")
 		}
 	}()
-	NewCountRateLimitMiddlewareBase(&CountRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+	NewCountRateLimitMiddlewareBase(1, 0)
+}
+
+func TestNewCountRateLimitMiddlewareBase_PanicOnNegativeBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative burst")
+		}
+	}()
+	NewCountRateLimitMiddlewareBase(1, -1)
 }

--- a/middleware_event_rate_limit.go
+++ b/middleware_event_rate_limit.go
@@ -1,0 +1,93 @@
+package mocrelay
+
+import (
+	"context"
+	"time"
+)
+
+// EventRateLimitMiddlewareOptions configures the middleware returned by
+// [NewEventRateLimitMiddlewareBase].
+//
+// Both fields are required. Zero or negative values cause the constructor
+// to panic, mirroring [NewMaxContentLengthMiddlewareBase] and friends.
+type EventRateLimitMiddlewareOptions struct {
+	// Rate is the long-term sustained rate of EVENT messages allowed per
+	// connection, in events per second.
+	Rate float64
+
+	// Burst is the maximum number of EVENT messages a connection may submit
+	// in a tight window before rate-limiting kicks in. The bucket starts
+	// full at connection start.
+	Burst float64
+}
+
+// NewEventRateLimitMiddlewareBase returns a middleware base that rate-limits
+// incoming EVENT messages on a per-connection basis using a token bucket.
+//
+// When the bucket is empty, the offending EVENT is dropped and a
+// `["OK", <id>, false, "rate-limited: too many events"]` is sent to the
+// client (NIP-01 standard prefix). REQ / CLOSE / AUTH / COUNT messages
+// pass through untouched -- compose with the matching per-type middleware
+// (Req/Count/Auth) if you need to limit those independently.
+//
+// The token bucket is created in OnStart and stored in the request
+// context, so each connection has its own independent bucket. Counters
+// are not shared across connections.
+//
+// Panics if opts is nil or if Rate / Burst is not positive.
+func NewEventRateLimitMiddlewareBase(opts *EventRateLimitMiddlewareOptions) SimpleMiddlewareBase {
+	if opts == nil {
+		panic("opts must not be nil")
+	}
+	if opts.Rate <= 0 {
+		panic("Rate must be positive")
+	}
+	if opts.Burst <= 0 {
+		panic("Burst must be positive")
+	}
+	return &eventRateLimitMiddleware{
+		rate:  opts.Rate,
+		burst: opts.Burst,
+	}
+}
+
+type eventRateLimitMiddleware struct {
+	rate  float64
+	burst float64
+}
+
+type eventRateLimitCtxKey struct{}
+
+func (m *eventRateLimitMiddleware) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
+	tb := newTokenBucket(m.rate, m.burst, time.Now())
+	ctx = context.WithValue(ctx, eventRateLimitCtxKey{}, tb)
+	return ctx, nil, nil
+}
+
+func (m *eventRateLimitMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
+	return nil, nil
+}
+
+func (m *eventRateLimitMiddleware) HandleClientMsg(ctx context.Context, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	if msg.Type != MsgTypeEvent {
+		return msg, nil, nil
+	}
+
+	tb := ctx.Value(eventRateLimitCtxKey{}).(*tokenBucket)
+	if tb.allow(time.Now()) {
+		return msg, nil, nil
+	}
+
+	eventID := ""
+	if msg.Event != nil {
+		eventID = msg.Event.ID
+	}
+	logRejection(ctx, "event_rate_limit", "rate_limited",
+		"event_id", eventID,
+	)
+	return nil, NewServerOKMsg(eventID, false, "rate-limited: too many events"), nil
+}
+
+func (m *eventRateLimitMiddleware) HandleServerMsg(ctx context.Context, msg *ServerMsg) (*ServerMsg, error) {
+	return msg, nil
+}

--- a/middleware_event_rate_limit.go
+++ b/middleware_event_rate_limit.go
@@ -5,24 +5,14 @@ import (
 	"time"
 )
 
-// EventRateLimitMiddlewareOptions configures the middleware returned by
-// [NewEventRateLimitMiddlewareBase].
-//
-// Both fields are required. Zero or negative values cause the constructor
-// to panic, mirroring [NewMaxContentLengthMiddlewareBase] and friends.
-type EventRateLimitMiddlewareOptions struct {
-	// Rate is the long-term sustained rate of EVENT messages allowed per
-	// connection, in events per second.
-	Rate float64
-
-	// Burst is the maximum number of EVENT messages a connection may submit
-	// in a tight window before rate-limiting kicks in. The bucket starts
-	// full at connection start.
-	Burst float64
-}
-
 // NewEventRateLimitMiddlewareBase returns a middleware base that rate-limits
 // incoming EVENT messages on a per-connection basis using a token bucket.
+//
+// rate is the long-term sustained rate of EVENT messages allowed per
+// connection, in events per second; must be positive.
+// burst is the maximum number of EVENT messages a connection may submit
+// in a tight window before rate-limiting kicks in. The bucket starts
+// full at connection start; must be positive.
 //
 // When the bucket is empty, the offending EVENT is dropped and a
 // `["OK", <id>, false, "rate-limited: too many events"]` is sent to the
@@ -34,26 +24,23 @@ type EventRateLimitMiddlewareOptions struct {
 // context, so each connection has its own independent bucket. Counters
 // are not shared across connections.
 //
-// Panics if opts is nil or if Rate / Burst is not positive.
-func NewEventRateLimitMiddlewareBase(opts *EventRateLimitMiddlewareOptions) SimpleMiddlewareBase {
-	if opts == nil {
-		panic("opts must not be nil")
+// Panics if rate <= 0 or burst < 1.
+func NewEventRateLimitMiddlewareBase(rate float64, burst int) SimpleMiddlewareBase {
+	if rate <= 0 {
+		panic("rate must be positive")
 	}
-	if opts.Rate <= 0 {
-		panic("Rate must be positive")
-	}
-	if opts.Burst <= 0 {
-		panic("Burst must be positive")
+	if burst < 1 {
+		panic("burst must be positive")
 	}
 	return &eventRateLimitMiddleware{
-		rate:  opts.Rate,
-		burst: opts.Burst,
+		rate:  rate,
+		burst: burst,
 	}
 }
 
 type eventRateLimitMiddleware struct {
 	rate  float64
-	burst float64
+	burst int
 }
 
 type eventRateLimitCtxKey struct{}

--- a/middleware_event_rate_limit_test.go
+++ b/middleware_event_rate_limit_test.go
@@ -26,9 +26,7 @@ func sendEventDrainOK(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerM
 
 func TestEventRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
-			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
-		))
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(1, 3))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -60,9 +58,7 @@ func TestEventRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 
 func TestEventRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
-			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
-		))
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(1, 2))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -109,9 +105,7 @@ func TestEventRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 
 func TestEventRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
-			&EventRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(2, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -139,6 +133,7 @@ func TestEventRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 
 		// Wait 1 second: rate=2 -> 2 tokens accumulated, but capped at burst=1.
 		// So one more allowed, then again rate-limited.
+		// (synctest.Test bubble: time.Sleep advances the fake clock, no real wait.)
 		time.Sleep(1 * time.Second)
 
 		third := sendEventDrainOK(t, recv, send, "ev")
@@ -158,9 +153,7 @@ func TestEventRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 
 func TestEventRateLimitMiddleware_NonEventPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
-			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(1, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -207,9 +200,7 @@ func TestEventRateLimitMiddleware_NonEventPassThrough(t *testing.T) {
 func TestEventRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
 	// Two independent connections share the same middleware instance.
 	// Draining one must NOT affect the other.
-	base := NewEventRateLimitMiddlewareBase(
-		&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-	)
+	base := NewEventRateLimitMiddlewareBase(1, 1)
 
 	runConn := func(t *testing.T) *ServerMsg {
 		var got *ServerMsg
@@ -241,47 +232,38 @@ func TestEventRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
 	}
 }
 
-func TestNewEventRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil opts")
-		}
-	}()
-	NewEventRateLimitMiddlewareBase(nil)
-}
-
 func TestNewEventRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Rate=0")
+			t.Fatal("expected panic for rate=0")
 		}
 	}()
-	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+	NewEventRateLimitMiddlewareBase(0, 1)
 }
 
 func TestNewEventRateLimitMiddlewareBase_PanicOnNegativeRate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for negative Rate")
+			t.Fatal("expected panic for negative rate")
 		}
 	}()
-	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: -1, Burst: 1})
+	NewEventRateLimitMiddlewareBase(-1, 1)
 }
 
 func TestNewEventRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Burst=0")
+			t.Fatal("expected panic for burst=0")
 		}
 	}()
-	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+	NewEventRateLimitMiddlewareBase(1, 0)
 }
 
 func TestNewEventRateLimitMiddlewareBase_PanicOnNegativeBurst(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for negative Burst")
+			t.Fatal("expected panic for negative burst")
 		}
 	}()
-	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 1, Burst: -1})
+	NewEventRateLimitMiddlewareBase(1, -1)
 }

--- a/middleware_event_rate_limit_test.go
+++ b/middleware_event_rate_limit_test.go
@@ -1,0 +1,287 @@
+package mocrelay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// helper: send one EVENT, wait, drain a single OK message and return it.
+func sendEventDrainOK(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg, id string) *ServerMsg {
+	t.Helper()
+	recv <- &ClientMsg{
+		Type:  MsgTypeEvent,
+		Event: &Event{ID: id, Content: "x"},
+	}
+	synctest.Wait()
+	select {
+	case msg := <-send:
+		return msg
+	default:
+		t.Fatal("expected message but got none")
+		return nil
+	}
+}
+
+func TestEventRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
+			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Burst=3 -> three EVENTs in immediate succession all pass through.
+		for i := range 3 {
+			msg := sendEventDrainOK(t, recv, send, "ok-event")
+			if msg.Type != MsgTypeOK {
+				t.Errorf("at %d: expected OK, got %v", i, msg.Type)
+			}
+			if !msg.Accepted {
+				t.Errorf("at %d: expected Accepted=true", i)
+			}
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestEventRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
+			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First two: accepted
+		for i := range 2 {
+			msg := sendEventDrainOK(t, recv, send, "rl-event")
+			if msg.Type != MsgTypeOK {
+				t.Errorf("at %d: expected OK, got %v", i, msg.Type)
+			}
+			if !msg.Accepted {
+				t.Errorf("at %d: expected Accepted=true", i)
+			}
+		}
+
+		// Third: rate-limited
+		msg := sendEventDrainOK(t, recv, send, "rl-event-3")
+		if msg.Type != MsgTypeOK {
+			t.Errorf("expected OK, got %v", msg.Type)
+		}
+		if msg.Accepted {
+			t.Error("expected Accepted=false")
+		}
+		if msg.Message != "rate-limited: too many events" {
+			t.Errorf("unexpected reason: %q", msg.Message)
+		}
+		if msg.EventID != "rl-event-3" {
+			t.Errorf("expected EventID=%q in OK, got %q", "rl-event-3", msg.EventID)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestEventRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
+			&EventRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First: accepted (consumes the only burst token)
+		first := sendEventDrainOK(t, recv, send, "ev")
+		if !first.Accepted {
+			t.Error("expected first event accepted")
+		}
+
+		// Second (immediately after): rate-limited
+		second := sendEventDrainOK(t, recv, send, "ev")
+		if second.Accepted {
+			t.Error("expected second event rate-limited")
+		}
+
+		// Wait 1 second: rate=2 -> 2 tokens accumulated, but capped at burst=1.
+		// So one more allowed, then again rate-limited.
+		time.Sleep(1 * time.Second)
+
+		third := sendEventDrainOK(t, recv, send, "ev")
+		if !third.Accepted {
+			t.Error("expected third event accepted after refill")
+		}
+
+		fourth := sendEventDrainOK(t, recv, send, "ev")
+		if fourth.Accepted {
+			t.Error("expected fourth event rate-limited (burst capped)")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestEventRateLimitMiddleware_NonEventPassThrough(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewEventRateLimitMiddlewareBase(
+			&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Drain the EVENT bucket so any EVENT would now be rate-limited.
+		first := sendEventDrainOK(t, recv, send, "e1")
+		if !first.Accepted {
+			t.Fatal("expected first event accepted")
+		}
+
+		// REQ should pass through to NopHandler -> EOSE (not rate-limited
+		// even though the EVENT bucket is empty).
+		limit := int64(0)
+		recv <- &ClientMsg{
+			Type:           MsgTypeReq,
+			SubscriptionID: "sub1",
+			Filters:        []*ReqFilter{{Limit: &limit}},
+		}
+		synctest.Wait()
+
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeEOSE {
+				t.Errorf("expected EOSE for REQ to pass through, got %v", msg.Type)
+			}
+		default:
+			t.Fatal("expected EOSE message but got none")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestEventRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
+	// Two independent connections share the same middleware instance.
+	// Draining one must NOT affect the other.
+	base := NewEventRateLimitMiddlewareBase(
+		&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+	)
+
+	runConn := func(t *testing.T) *ServerMsg {
+		var got *ServerMsg
+		synctest.Test(t, func(t *testing.T) {
+			handler := NewSimpleMiddleware(base)(NewNopHandler())
+			recv := make(chan *ClientMsg)
+			send := make(chan *ServerMsg, 4)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error)
+			go func() { done <- handler.ServeNostr(ctx, send, recv) }()
+
+			got = sendEventDrainOK(t, recv, send, "e")
+
+			cancel()
+			<-done
+		})
+		return got
+	}
+
+	first := runConn(t)
+	if !first.Accepted {
+		t.Error("conn1: expected first event accepted")
+	}
+
+	second := runConn(t)
+	if !second.Accepted {
+		t.Error("conn2: expected first event accepted (per-connection bucket)")
+	}
+}
+
+func TestNewEventRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil opts")
+		}
+	}()
+	NewEventRateLimitMiddlewareBase(nil)
+}
+
+func TestNewEventRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Rate=0")
+		}
+	}()
+	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+}
+
+func TestNewEventRateLimitMiddlewareBase_PanicOnNegativeRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative Rate")
+		}
+	}()
+	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: -1, Burst: 1})
+}
+
+func TestNewEventRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Burst=0")
+		}
+	}()
+	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+}
+
+func TestNewEventRateLimitMiddlewareBase_PanicOnNegativeBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative Burst")
+		}
+	}()
+	NewEventRateLimitMiddlewareBase(&EventRateLimitMiddlewareOptions{Rate: 1, Burst: -1})
+}

--- a/middleware_req_rate_limit.go
+++ b/middleware_req_rate_limit.go
@@ -1,0 +1,85 @@
+package mocrelay
+
+import (
+	"context"
+	"time"
+)
+
+// ReqRateLimitMiddlewareOptions configures the middleware returned by
+// [NewReqRateLimitMiddlewareBase]. Both fields are required; zero or
+// negative values cause the constructor to panic.
+type ReqRateLimitMiddlewareOptions struct {
+	// Rate is the long-term sustained rate of REQ messages allowed per
+	// connection, in REQs per second.
+	Rate float64
+
+	// Burst is the maximum number of REQ messages a connection may submit
+	// in a tight window before rate-limiting kicks in. The bucket starts
+	// full at connection start.
+	Burst float64
+}
+
+// NewReqRateLimitMiddlewareBase returns a middleware base that rate-limits
+// incoming REQ messages on a per-connection basis using a token bucket.
+//
+// When the bucket is empty, the offending REQ is dropped and a
+// `["CLOSED", <sub_id>, "rate-limited: too many subscriptions"]` is sent
+// to the client. EVENT / CLOSE / AUTH / COUNT messages pass through
+// untouched -- compose with the matching per-type middleware
+// (Event/Count/Auth) if you need to limit those independently.
+//
+// Each connection gets its own token bucket via OnStart + context.
+//
+// Panics if opts is nil or if Rate / Burst is not positive.
+func NewReqRateLimitMiddlewareBase(opts *ReqRateLimitMiddlewareOptions) SimpleMiddlewareBase {
+	if opts == nil {
+		panic("opts must not be nil")
+	}
+	if opts.Rate <= 0 {
+		panic("Rate must be positive")
+	}
+	if opts.Burst <= 0 {
+		panic("Burst must be positive")
+	}
+	return &reqRateLimitMiddleware{
+		rate:  opts.Rate,
+		burst: opts.Burst,
+	}
+}
+
+type reqRateLimitMiddleware struct {
+	rate  float64
+	burst float64
+}
+
+type reqRateLimitCtxKey struct{}
+
+func (m *reqRateLimitMiddleware) OnStart(ctx context.Context) (context.Context, *ServerMsg, error) {
+	tb := newTokenBucket(m.rate, m.burst, time.Now())
+	ctx = context.WithValue(ctx, reqRateLimitCtxKey{}, tb)
+	return ctx, nil, nil
+}
+
+func (m *reqRateLimitMiddleware) OnEnd(ctx context.Context) (*ServerMsg, error) {
+	return nil, nil
+}
+
+func (m *reqRateLimitMiddleware) HandleClientMsg(ctx context.Context, msg *ClientMsg) (*ClientMsg, *ServerMsg, error) {
+	if msg.Type != MsgTypeReq {
+		return msg, nil, nil
+	}
+
+	tb := ctx.Value(reqRateLimitCtxKey{}).(*tokenBucket)
+	if tb.allow(time.Now()) {
+		return msg, nil, nil
+	}
+
+	logRejection(ctx, "req_rate_limit", "rate_limited",
+		"sub_id", msg.SubscriptionID,
+	)
+	return nil, NewServerClosedMsg(msg.SubscriptionID, "rate-limited: too many subscriptions"), nil
+}
+
+func (m *reqRateLimitMiddleware) HandleServerMsg(ctx context.Context, msg *ServerMsg) (*ServerMsg, error) {
+	return msg, nil
+}

--- a/middleware_req_rate_limit.go
+++ b/middleware_req_rate_limit.go
@@ -5,22 +5,14 @@ import (
 	"time"
 )
 
-// ReqRateLimitMiddlewareOptions configures the middleware returned by
-// [NewReqRateLimitMiddlewareBase]. Both fields are required; zero or
-// negative values cause the constructor to panic.
-type ReqRateLimitMiddlewareOptions struct {
-	// Rate is the long-term sustained rate of REQ messages allowed per
-	// connection, in REQs per second.
-	Rate float64
-
-	// Burst is the maximum number of REQ messages a connection may submit
-	// in a tight window before rate-limiting kicks in. The bucket starts
-	// full at connection start.
-	Burst float64
-}
-
 // NewReqRateLimitMiddlewareBase returns a middleware base that rate-limits
 // incoming REQ messages on a per-connection basis using a token bucket.
+//
+// rate is the long-term sustained rate of REQ messages allowed per
+// connection, in REQs per second; must be positive.
+// burst is the maximum number of REQ messages a connection may submit
+// in a tight window before rate-limiting kicks in. The bucket starts
+// full at connection start; must be positive.
 //
 // When the bucket is empty, the offending REQ is dropped and a
 // `["CLOSED", <sub_id>, "rate-limited: too many subscriptions"]` is sent
@@ -30,26 +22,23 @@ type ReqRateLimitMiddlewareOptions struct {
 //
 // Each connection gets its own token bucket via OnStart + context.
 //
-// Panics if opts is nil or if Rate / Burst is not positive.
-func NewReqRateLimitMiddlewareBase(opts *ReqRateLimitMiddlewareOptions) SimpleMiddlewareBase {
-	if opts == nil {
-		panic("opts must not be nil")
+// Panics if rate <= 0 or burst < 1.
+func NewReqRateLimitMiddlewareBase(rate float64, burst int) SimpleMiddlewareBase {
+	if rate <= 0 {
+		panic("rate must be positive")
 	}
-	if opts.Rate <= 0 {
-		panic("Rate must be positive")
-	}
-	if opts.Burst <= 0 {
-		panic("Burst must be positive")
+	if burst < 1 {
+		panic("burst must be positive")
 	}
 	return &reqRateLimitMiddleware{
-		rate:  opts.Rate,
-		burst: opts.Burst,
+		rate:  rate,
+		burst: burst,
 	}
 }
 
 type reqRateLimitMiddleware struct {
 	rate  float64
-	burst float64
+	burst int
 }
 
 type reqRateLimitCtxKey struct{}

--- a/middleware_req_rate_limit_test.go
+++ b/middleware_req_rate_limit_test.go
@@ -28,9 +28,7 @@ func sendReqDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg, 
 
 func TestReqRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
-			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
-		))
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(1, 3))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -59,9 +57,7 @@ func TestReqRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
 
 func TestReqRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
-			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
-		))
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(1, 2))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -102,9 +98,7 @@ func TestReqRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
 
 func TestReqRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
-			&ReqRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(2, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -129,6 +123,7 @@ func TestReqRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 		}
 
 		// Wait 1 second: bucket refilled (capped at burst=1)
+		// (synctest.Test bubble: time.Sleep advances the fake clock, no real wait.)
 		time.Sleep(1 * time.Second)
 
 		third := sendReqDrain(t, recv, send, "s")
@@ -148,9 +143,7 @@ func TestReqRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
 
 func TestReqRateLimitMiddleware_NonReqPassThrough(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
-			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-		))
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(1, 1))
 		handler := middleware(NewNopHandler())
 
 		recv := make(chan *ClientMsg)
@@ -194,9 +187,7 @@ func TestReqRateLimitMiddleware_NonReqPassThrough(t *testing.T) {
 }
 
 func TestReqRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
-	base := NewReqRateLimitMiddlewareBase(
-		&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
-	)
+	base := NewReqRateLimitMiddlewareBase(1, 1)
 
 	runConn := func(t *testing.T) *ServerMsg {
 		var got *ServerMsg
@@ -227,29 +218,38 @@ func TestReqRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
 	}
 }
 
-func TestNewReqRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil opts")
-		}
-	}()
-	NewReqRateLimitMiddlewareBase(nil)
-}
-
 func TestNewReqRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Rate=0")
+			t.Fatal("expected panic for rate=0")
 		}
 	}()
-	NewReqRateLimitMiddlewareBase(&ReqRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+	NewReqRateLimitMiddlewareBase(0, 1)
+}
+
+func TestNewReqRateLimitMiddlewareBase_PanicOnNegativeRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative rate")
+		}
+	}()
+	NewReqRateLimitMiddlewareBase(-1, 1)
 }
 
 func TestNewReqRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for Burst=0")
+			t.Fatal("expected panic for burst=0")
 		}
 	}()
-	NewReqRateLimitMiddlewareBase(&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+	NewReqRateLimitMiddlewareBase(1, 0)
+}
+
+func TestNewReqRateLimitMiddlewareBase_PanicOnNegativeBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative burst")
+		}
+	}()
+	NewReqRateLimitMiddlewareBase(1, -1)
 }

--- a/middleware_req_rate_limit_test.go
+++ b/middleware_req_rate_limit_test.go
@@ -1,0 +1,255 @@
+package mocrelay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// helper: send one REQ, wait, drain a single message and return it.
+func sendReqDrain(t *testing.T, recv chan<- *ClientMsg, send <-chan *ServerMsg, subID string) *ServerMsg {
+	t.Helper()
+	limit := int64(0)
+	recv <- &ClientMsg{
+		Type:           MsgTypeReq,
+		SubscriptionID: subID,
+		Filters:        []*ReqFilter{{Limit: &limit}},
+	}
+	synctest.Wait()
+	select {
+	case msg := <-send:
+		return msg
+	default:
+		t.Fatal("expected message but got none")
+		return nil
+	}
+}
+
+func TestReqRateLimitMiddleware_AllowWithinBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
+			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 3},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Burst=3 -> three REQs in immediate succession all reach NopHandler -> EOSE.
+		for i := range 3 {
+			msg := sendReqDrain(t, recv, send, "sub")
+			if msg.Type != MsgTypeEOSE {
+				t.Errorf("at %d: expected EOSE, got %v", i, msg.Type)
+			}
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestReqRateLimitMiddleware_RejectAfterBurst(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
+			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 2},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// First two: EOSE
+		for i := range 2 {
+			msg := sendReqDrain(t, recv, send, "sub")
+			if msg.Type != MsgTypeEOSE {
+				t.Errorf("at %d: expected EOSE, got %v", i, msg.Type)
+			}
+		}
+
+		// Third: CLOSED with rate-limited prefix
+		msg := sendReqDrain(t, recv, send, "sub-3")
+		if msg.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED, got %v", msg.Type)
+		}
+		if msg.Message != "rate-limited: too many subscriptions" {
+			t.Errorf("unexpected reason: %q", msg.Message)
+		}
+		if msg.SubscriptionID != "sub-3" {
+			t.Errorf("expected sub_id=%q, got %q", "sub-3", msg.SubscriptionID)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestReqRateLimitMiddleware_RecoversAfterWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
+			&ReqRateLimitMiddlewareOptions{Rate: 2, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		first := sendReqDrain(t, recv, send, "s")
+		if first.Type != MsgTypeEOSE {
+			t.Errorf("expected EOSE, got %v", first.Type)
+		}
+
+		second := sendReqDrain(t, recv, send, "s")
+		if second.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED for rate-limited REQ, got %v", second.Type)
+		}
+
+		// Wait 1 second: bucket refilled (capped at burst=1)
+		time.Sleep(1 * time.Second)
+
+		third := sendReqDrain(t, recv, send, "s")
+		if third.Type != MsgTypeEOSE {
+			t.Errorf("expected EOSE after refill, got %v", third.Type)
+		}
+
+		fourth := sendReqDrain(t, recv, send, "s")
+		if fourth.Type != MsgTypeClosed {
+			t.Errorf("expected CLOSED (burst capped), got %v", fourth.Type)
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestReqRateLimitMiddleware_NonReqPassThrough(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		middleware := NewSimpleMiddleware(NewReqRateLimitMiddlewareBase(
+			&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+		))
+		handler := middleware(NewNopHandler())
+
+		recv := make(chan *ClientMsg)
+		send := make(chan *ServerMsg, 10)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			done <- handler.ServeNostr(ctx, send, recv)
+		}()
+
+		// Drain the REQ bucket
+		first := sendReqDrain(t, recv, send, "s1")
+		if first.Type != MsgTypeEOSE {
+			t.Fatalf("expected EOSE, got %v", first.Type)
+		}
+
+		// EVENT must pass through (REQ bucket empty does NOT affect EVENT)
+		recv <- &ClientMsg{
+			Type:  MsgTypeEvent,
+			Event: &Event{ID: "ev", Content: "x"},
+		}
+		synctest.Wait()
+		select {
+		case msg := <-send:
+			if msg.Type != MsgTypeOK {
+				t.Errorf("expected OK for EVENT pass-through, got %v", msg.Type)
+			}
+			if !msg.Accepted {
+				t.Error("expected EVENT accepted")
+			}
+		default:
+			t.Fatal("expected EVENT response")
+		}
+
+		cancel()
+		<-done
+	})
+}
+
+func TestReqRateLimitMiddleware_PerConnectionIsolation(t *testing.T) {
+	base := NewReqRateLimitMiddlewareBase(
+		&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 1},
+	)
+
+	runConn := func(t *testing.T) *ServerMsg {
+		var got *ServerMsg
+		synctest.Test(t, func(t *testing.T) {
+			handler := NewSimpleMiddleware(base)(NewNopHandler())
+			recv := make(chan *ClientMsg)
+			send := make(chan *ServerMsg, 4)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error)
+			go func() { done <- handler.ServeNostr(ctx, send, recv) }()
+
+			got = sendReqDrain(t, recv, send, "s")
+
+			cancel()
+			<-done
+		})
+		return got
+	}
+
+	first := runConn(t)
+	if first.Type != MsgTypeEOSE {
+		t.Errorf("conn1: expected EOSE, got %v", first.Type)
+	}
+	second := runConn(t)
+	if second.Type != MsgTypeEOSE {
+		t.Errorf("conn2: expected EOSE (per-connection bucket), got %v", second.Type)
+	}
+}
+
+func TestNewReqRateLimitMiddlewareBase_PanicOnNilOpts(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil opts")
+		}
+	}()
+	NewReqRateLimitMiddlewareBase(nil)
+}
+
+func TestNewReqRateLimitMiddlewareBase_PanicOnZeroRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Rate=0")
+		}
+	}()
+	NewReqRateLimitMiddlewareBase(&ReqRateLimitMiddlewareOptions{Rate: 0, Burst: 1})
+}
+
+func TestNewReqRateLimitMiddlewareBase_PanicOnZeroBurst(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for Burst=0")
+		}
+	}()
+	NewReqRateLimitMiddlewareBase(&ReqRateLimitMiddlewareOptions{Rate: 1, Burst: 0})
+}

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -23,12 +23,15 @@ type tokenBucket struct {
 }
 
 // newTokenBucket constructs a token bucket with the given rate and burst,
-// starting full at the given time.
-func newTokenBucket(rate, burst float64, now time.Time) *tokenBucket {
+// starting full at the given time. Burst is taken as int because messages
+// are integral; the bucket itself stores tokens as float64 internally so
+// fractional refills (e.g. half a token after 0.5s at rate=1) accumulate
+// correctly across calls.
+func newTokenBucket(rate float64, burst int, now time.Time) *tokenBucket {
 	return &tokenBucket{
 		rate:       rate,
-		burst:      burst,
-		tokens:     burst,
+		burst:      float64(burst),
+		tokens:     float64(burst),
 		lastUpdate: now,
 	}
 }

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -1,0 +1,55 @@
+package mocrelay
+
+import (
+	"math"
+	"time"
+)
+
+// tokenBucket is an internal token-bucket rate limiter used by the
+// per-message-type rate limit middlewares (Event/Req/Count/Auth).
+//
+// It is intentionally not safe for concurrent use: each instance is owned
+// by a single connection and accessed only from the simpleMiddlewarePipelineLoop
+// goroutine that drives that connection.
+//
+// The bucket starts full (tokens = burst) so a freshly-connected client can
+// burst up to `burst` requests immediately, then is rate-limited to `rate`
+// requests per second long-term.
+type tokenBucket struct {
+	rate       float64 // tokens added per second
+	burst      float64 // maximum tokens the bucket can hold
+	tokens     float64 // current tokens
+	lastUpdate time.Time
+}
+
+// newTokenBucket constructs a token bucket with the given rate and burst,
+// starting full at the given time.
+func newTokenBucket(rate, burst float64, now time.Time) *tokenBucket {
+	return &tokenBucket{
+		rate:       rate,
+		burst:      burst,
+		tokens:     burst,
+		lastUpdate: now,
+	}
+}
+
+// allow attempts to consume one token. Returns true if a token was available
+// (the request is permitted), false if the bucket is empty (the request must
+// be rate-limited).
+//
+// The bucket is refilled lazily at call time based on elapsed wall-clock time
+// since the last call. Backwards or zero elapsed time is treated as zero
+// elapsed -- the bucket never gains tokens from clock skew.
+func (tb *tokenBucket) allow(now time.Time) bool {
+	elapsed := now.Sub(tb.lastUpdate).Seconds()
+	if elapsed > 0 {
+		tb.tokens = math.Min(tb.burst, tb.tokens+elapsed*tb.rate)
+		tb.lastUpdate = now
+	}
+
+	if tb.tokens >= 1 {
+		tb.tokens -= 1
+		return true
+	}
+	return false
+}

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,0 +1,114 @@
+package mocrelay
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenBucket_InitialBurstAllowed(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 5, now)
+
+	// Should allow exactly burst (5) consecutive requests at t=0
+	for i := range 5 {
+		if !tb.allow(now) {
+			t.Fatalf("expected allow at iteration %d", i)
+		}
+	}
+
+	// 6th must be rejected: bucket exhausted, no time has passed
+	if tb.allow(now) {
+		t.Fatal("expected reject after exhausting burst")
+	}
+}
+
+func TestTokenBucket_RefillByElapsed(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(2, 1, now) // 2 tokens/sec, burst 1
+
+	// Consume the only burst token
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+	if tb.allow(now) {
+		t.Fatal("expected immediate reject")
+	}
+
+	// After 0.5s exactly 1 token should be available (rate=2 -> 1 per 0.5s)
+	now = now.Add(500 * time.Millisecond)
+	if !tb.allow(now) {
+		t.Fatal("expected allow after 0.5s refill")
+	}
+
+	// And then immediately reject again (we drained it)
+	if tb.allow(now) {
+		t.Fatal("expected reject after consuming refilled token")
+	}
+}
+
+func TestTokenBucket_RefillCapsAtBurst(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 3, now) // 1 token/sec, burst 3
+
+	// Exhaust
+	for i := range 3 {
+		if !tb.allow(now) {
+			t.Fatalf("expected initial allow at %d", i)
+		}
+	}
+
+	// Wait 100 seconds - well more than enough to fill way past burst
+	now = now.Add(100 * time.Second)
+
+	// Should allow exactly 3 (capped at burst), not 100
+	for i := range 3 {
+		if !tb.allow(now) {
+			t.Fatalf("expected allow at %d after long wait", i)
+		}
+	}
+
+	if tb.allow(now) {
+		t.Fatal("expected reject: refill must cap at burst, not accumulate")
+	}
+}
+
+func TestTokenBucket_FractionalAccumulation(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 1, now) // 1 token/sec, burst 1
+
+	// Consume initial token
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+
+	// Two consecutive 0.6s waits: each accumulates 0.6 token, but the
+	// first 0.6 is below the 1.0 threshold so allow must reject;
+	// after the second wait the bucket has min(1, 1.2) = 1.0 -> allow.
+	now = now.Add(600 * time.Millisecond)
+	if tb.allow(now) {
+		t.Fatal("expected reject at 0.6s (only 0.6 token accumulated)")
+	}
+
+	now = now.Add(600 * time.Millisecond)
+	if !tb.allow(now) {
+		t.Fatal("expected allow at 1.2s (token threshold reached)")
+	}
+}
+
+func TestTokenBucket_BackwardsClockIgnored(t *testing.T) {
+	// If somehow now goes backwards (clock skew, test mistake, ...) the
+	// bucket must not credit negative time and start handing out tokens
+	// on every call. Pin lastUpdate forward by ignoring elapsed <= 0.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 1, start)
+
+	if !tb.allow(start) {
+		t.Fatal("expected initial allow")
+	}
+
+	// Move backward 10s -- should still be rejected, not refilled
+	earlier := start.Add(-10 * time.Second)
+	if tb.allow(earlier) {
+		t.Fatal("expected reject when clock moves backwards")
+	}
+}


### PR DESCRIPTION
## Summary

- Add four new `SimpleMiddlewareBase` types — `EventRateLimitMiddlewareBase`, `ReqRateLimitMiddlewareBase`, `CountRateLimitMiddlewareBase`, `AuthRateLimitMiddlewareBase` — each rate-limiting one Nostr message type on a per-connection basis using a shared internal `tokenBucket` helper.
- All four follow the same shape: `New{Type}RateLimitMiddlewareBase(rate float64, burst int)` (panic on `rate <= 0` or `burst < 1`), a token bucket allocated in `OnStart` and stashed in the request context, and rejection emitted via `logRejection` so it cross-indexes with `mocrelay_rejections_total{middleware, reason}`.
- Rejection wire format follows NIP-01:
  - EVENT → `[\"OK\", <id>, false, \"rate-limited: too many events\"]`
  - REQ → `[\"CLOSED\", <sub_id>, \"rate-limited: too many subscriptions\"]`
  - COUNT → `[\"CLOSED\", <sub_id>, \"rate-limited: too many counts\"]`
  - AUTH → `[\"OK\", <event_id>, false, \"rate-limited: too many auth attempts\"]` (NIP-42 responds with OK)
- Buckets are independent per type and per connection. The middleware instance itself is shared across connections; only the bucket state is per-connection (memory cost \`O(connections × middlewares_enabled)\`).

## Why

mocrelay had no rate-limit primitives. Operators currently rely on either upstream proxies or custom middleware to throttle abusive clients. Adding type-aware rate limiting at the application layer (after parse, before storage / handler dispatch) lets operators tune EVENT vs REQ vs COUNT vs AUTH separately — for example, a low rate on AUTH (e.g. \`rate=0.1, burst=3\`) to throttle credential stuffing while leaving EVENT submissions generous.

Wire-level rate limiting (per-IP / per-pubkey / global, or limiting WebSocket message rate before parse) is intentionally out of scope and remains a separate-layer concern.

## Commit structure (4 + 1 + 1)

PR is split into deliberately small commits so reviewers can track the pattern emerging:

1. **EVENT** + shared \`tokenBucket\` helper (the new code is the helper; commits 2-4 just reuse it)
2. **REQ** — symmetric to EVENT, returns CLOSED instead of OK
3. **COUNT** — symmetric to REQ, separate bucket so REQ and COUNT can be tuned independently
4. **AUTH** — symmetric to EVENT (NIP-42 responds with OK), nil-Event tolerated
5. **CLAUDE.md** — new \"Operational Hardening (NIP-independent)\" subsection summarizing the four middlewares and the deliberate scope limits
6. **review feedback** — per spirit review: drop the Options struct in favor of positional args (\`rate float64, burst int\`) following the \`NewMaxLimitMiddlewareBase\` shape and CLAUDE.md \"Constructor API\" Exceptions clause; unify panic test coverage across all four middlewares (zero / negative for both rate and burst)

## Test plan

- [x] \`go test ./...\` — all existing tests still pass; ~30 new test cases across the four middlewares + tokenBucket (allow within burst / reject after burst / refill after wait via synctest fake clock / per-connection isolation / non-target message pass-through / panic on zero or negative rate or burst)
- [x] \`go vet ./...\`
- [x] \`lefthook\` pre-commit hooks pass on every commit
- [x] CI green
- [x] Spirit review (🦍🍍🍋) — all three approved, no blockers

🌸 Generated with [Claude Code](https://claude.com/claude-code)