### PR TITLE
feat: per-connection readLoop rate limit (RelayOptions.ReadRate / ReadBurst)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -772,9 +772,17 @@ This is mocrelay's main value proposition.
 
 #### Operational Hardening (NIP-independent) ✅
 
-These middlewares are not tied to any NIP. They throttle abusive client
-behavior at the application layer (after parse, before storage /
-handler dispatch).
+mocrelay throttles abusive per-connection traffic at two complementary
+layers: the **readLoop layer** (a coarse total cap that stalls before
+parse / verify) and the **application layer** (per-message-type
+middlewares that reject after parse). They compose -- enable both for
+defense in depth.
+
+##### Application-layer middlewares
+
+These middlewares run after parse / signature verify and reject
+offending messages with a category-specific reason. Use them to tune
+budgets per message type.
 
 | Middleware | Purpose | Reject |
 |------------|---------|--------|
@@ -807,11 +815,50 @@ interact across types. A typical hardened relay enables all four with
 deliberately different limits — e.g. `Rate=10, Burst=20` for EVENT but
 `Rate=0.1, Burst=3` for AUTH to throttle credential stuffing.
 
-**Out of scope**: per-IP / per-pubkey / global limits, and limiting
-the total WebSocket message rate before parse. Those belong in a
-different layer (the WebSocket readLoop or an external reverse proxy)
-and would couple to identity / network topology that the middleware
-layer cannot see.
+##### readLoop-layer rate limit (`RelayOptions.ReadRate` / `ReadBurst`)
+
+`RelayOptions.ReadRate` / `ReadBurst` is a per-connection token bucket
+that **stalls** the readLoop *before* `conn.Read` when the budget is
+exhausted, rather than rejecting after parse. Throttled clients never
+cost the relay parse or signature-verification CPU; back-pressure
+rides on the TCP receive window once the OS-level WebSocket buffer
+fills, so the slowdown propagates all the way to the misbehaving peer
+without any explicit reject signal.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ReadRate` | float64 | messages/sec; `<= 0` disables (default) |
+| `ReadBurst` | int | bucket capacity; must be `>= 1` if `ReadRate > 0` (constructor panics otherwise) |
+
+Internally uses the same `tokenBucket` helper as the application-layer
+middlewares plus a `waitDuration(now)` method (returns when the next
+token will refill). The `readStall` helper drives the wait loop, runs
+once per readLoop iteration before `conn.Read`, and short-circuits to
+nil on `bucket == nil` so the disabled path costs only a nil check
+per message.
+
+**Observability**: `mocrelay_read_stalls_total` counter increments
+**once per stall window** (one entry into the slow path = one client
+hitting the budget). Inner-loop retries inside `readStall` do not
+double-count, so the rate of this counter is "how many distinct stall
+events" rather than "how many sleep cycles," matching how an operator
+thinks about throttling.
+
+##### Layer composition
+
+readLoop is the **coarse floodgate** (category-agnostic, total
+messages/sec cap, stops parse / verify cost). Middlewares **refine per
+category** (after parse, with full message-type awareness, reject
+semantics). A typical hardened relay sets `ReadRate` / `ReadBurst`
+generously to absorb normal bursts, then tightens category caps via
+the middlewares -- e.g. `ReadRate=50, ReadBurst=100` paired with
+`AuthRateLimit(0.1, 3)` and `EventRateLimit(10, 20)`.
+
+**Out of scope** at both layers: per-IP / per-pubkey / global limits.
+Those belong in an external reverse proxy or a higher-level identity
+layer; mocrelay does not see network topology, and per-pubkey would
+require parse + verify before classification (defeating the readLoop
+layer's CPU savings).
 
 #### Future NIP Implementation Priority
 

--- a/metrics.go
+++ b/metrics.go
@@ -29,6 +29,16 @@ type relayMetrics struct {
 	// writeLoop. Diagnoses slow clients / saturated send paths that can
 	// cause write timeouts and ping-starvation.
 	WSWriteDuration prometheus.Histogram
+
+	// ReadStallsTotal counts how many times the readLoop has been forced
+	// to wait on the per-connection read rate limit (RelayOptions.ReadRate
+	// / ReadBurst). Counted at most once per stall window: a client that
+	// is throttled across many consecutive reads bumps this once per slow
+	// path entry, not per inner-loop retry.
+	//
+	// Zero on relays that don't configure ReadRate; nonzero rates here
+	// mean at least one client is exceeding the configured read budget.
+	ReadStallsTotal prometheus.Counter
 }
 
 // newRelayMetrics creates and registers Relay metrics with reg.
@@ -77,6 +87,12 @@ func newRelayMetrics(reg prometheus.Registerer) *relayMetrics {
 			Help:    "Time spent in each WebSocket conn.Write call in the writeLoop",
 			Buckets: prometheus.DefBuckets,
 		}),
+		ReadStallsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "mocrelay_read_stalls_total",
+			Help: "Total number of times the readLoop stalled waiting on the " +
+				"per-connection read rate limit (RelayOptions.ReadRate). Counted " +
+				"once per stall window, not per inner-loop retry.",
+		}),
 	}
 
 	reg.MustRegister(
@@ -88,6 +104,7 @@ func newRelayMetrics(reg prometheus.Registerer) *relayMetrics {
 		m.WSParseErrors,
 		m.WSWriteErrors,
 		m.WSWriteDuration,
+		m.ReadStallsTotal,
 	)
 
 	return m

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -72,13 +72,14 @@ func (tb *tokenBucket) allow(now time.Time) bool {
 // allow(): the bucket never credits clock skew, so the reported wait is
 // always the conservative "full refill from current state" duration.
 //
-// Invariant: when allow() would return false (bucket has < 1 token), the
-// returned duration is strictly positive -- never zero. readStall's loop
-// relies on this to avoid a tight retry spin: a zero duration would make
-// time.After(0) fire immediately, allow() would still fail, and the loop
-// would burn CPU until refill caught up. If you ever change the formula
-// here so that it can return 0 for the "no token" case, you must add a
-// floor in readStall as well.
+// Practical note on rounding: in normal use the returned duration is
+// strictly positive whenever allow() would return false. But the
+// float-to-int64 conversion can round (1 - tokens) / rate down to 0 ns
+// in extreme cases -- e.g. tokens = 0.9999999999 with a high rate, where
+// the true deficit is < 1 ns. readStall guards against the resulting
+// tight-spin with a millisecond floor in its sleep loop; treat that
+// floor as part of waitDuration's contract in any caller that wants to
+// drive a stall loop with the same invariant.
 func (tb *tokenBucket) waitDuration(now time.Time) time.Duration {
 	elapsed := now.Sub(tb.lastUpdate).Seconds()
 	tokens := tb.tokens
@@ -132,6 +133,16 @@ func readStall(ctx context.Context, bucket *tokenBucket, onStall func()) error {
 	}
 	for {
 		d := bucket.waitDuration(time.Now())
+		// Floor against rounding-to-zero. waitDuration computes
+		// (1 - tokens) / rate in float and converts to int64 ns, which can
+		// drop to 0 for tiny fractional deficits at high rates. time.After(0)
+		// would fire immediately, allow() would still fail, and the loop
+		// would tight-spin until refill caught up. A 1ms floor keeps the
+		// backoff bounded; real refill windows in production are orders of
+		// magnitude larger so the floor is invisible to legitimate callers.
+		if d <= 0 {
+			d = time.Millisecond
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -71,6 +71,14 @@ func (tb *tokenBucket) allow(now time.Time) bool {
 // Backwards or zero elapsed time is treated as zero elapsed, mirroring
 // allow(): the bucket never credits clock skew, so the reported wait is
 // always the conservative "full refill from current state" duration.
+//
+// Invariant: when allow() would return false (bucket has < 1 token), the
+// returned duration is strictly positive -- never zero. readStall's loop
+// relies on this to avoid a tight retry spin: a zero duration would make
+// time.After(0) fire immediately, allow() would still fail, and the loop
+// would burn CPU until refill caught up. If you ever change the formula
+// here so that it can return 0 for the "no token" case, you must add a
+// floor in readStall as well.
 func (tb *tokenBucket) waitDuration(now time.Time) time.Duration {
 	elapsed := now.Sub(tb.lastUpdate).Seconds()
 	tokens := tb.tokens
@@ -103,9 +111,18 @@ func (tb *tokenBucket) waitDuration(now time.Time) time.Duration {
 // least once) without double-counting noise from the inner loop.
 //
 // Returns nil on success, ctx.Err() on cancel.
+//
+// A pre-canceled ctx short-circuits before allow() is consulted, so a
+// connection that's already going away cannot debit a token from the
+// bucket. This keeps readStall consistent with the readLoop's other ctx
+// observation points -- conn.Read(ctx) would also fail immediately on a
+// canceled ctx -- and avoids burning bucket capacity on dead conns.
 func readStall(ctx context.Context, bucket *tokenBucket, onStall func()) error {
 	if bucket == nil {
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if bucket.allow(time.Now()) {
 		return nil

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -1,6 +1,7 @@
 package mocrelay
 
 import (
+	"context"
 	"math"
 	"time"
 )
@@ -81,4 +82,46 @@ func (tb *tokenBucket) waitDuration(now time.Time) time.Duration {
 	}
 	needed := 1 - tokens
 	return time.Duration(needed / tb.rate * float64(time.Second))
+}
+
+// readStall blocks until bucket allows one token, or ctx is done.
+//
+// This drives the readLoop-level rate limit (RelayOptions.ReadRate /
+// ReadBurst), where the policy is to STALL the read rather than reject
+// the message: the WebSocket conn.Read is simply not invoked until a
+// token is available. Back-pressure propagates naturally to the client
+// via the TCP receive window once the OS buffer fills.
+//
+// A nil bucket means rate limiting is disabled and readStall returns
+// immediately without consulting ctx -- the caller pays no overhead.
+//
+// onStall is invoked exactly once per stall window: when the fast path
+// fails and the slow loop is entered. Subsequent allow() failures inside
+// the loop (which happen if the clock jitters or refill rate is very
+// low) do not re-trigger it. Pass nil to skip. This shape lets callers
+// increment a "stalls" Counter (one stall = one client throttled at
+// least once) without double-counting noise from the inner loop.
+//
+// Returns nil on success, ctx.Err() on cancel.
+func readStall(ctx context.Context, bucket *tokenBucket, onStall func()) error {
+	if bucket == nil {
+		return nil
+	}
+	if bucket.allow(time.Now()) {
+		return nil
+	}
+	if onStall != nil {
+		onStall()
+	}
+	for {
+		d := bucket.waitDuration(time.Now())
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(d):
+		}
+		if bucket.allow(time.Now()) {
+			return nil
+		}
+	}
 }

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -6,11 +6,12 @@ import (
 )
 
 // tokenBucket is an internal token-bucket rate limiter used by the
-// per-message-type rate limit middlewares (Event/Req/Count/Auth).
+// per-message-type rate limit middlewares (Event/Req/Count/Auth) and by
+// the Relay's readLoop-level stall (RelayOptions.ReadRate).
 //
 // It is intentionally not safe for concurrent use: each instance is owned
-// by a single connection and accessed only from the simpleMiddlewarePipelineLoop
-// goroutine that drives that connection.
+// by a single connection and accessed only from the goroutine that drives
+// that connection (a simpleMiddlewarePipelineLoop, or the readLoop itself).
 //
 // The bucket starts full (tokens = burst) so a freshly-connected client can
 // burst up to `burst` requests immediately, then is rate-limited to `rate`
@@ -55,4 +56,29 @@ func (tb *tokenBucket) allow(now time.Time) bool {
 		return true
 	}
 	return false
+}
+
+// waitDuration returns how long the caller must wait before allow() would
+// next succeed. Returns 0 if a token is already available.
+//
+// This is a pure read of the bucket state: it does not consume tokens and
+// does not advance lastUpdate, so calling it twice in a row with the same
+// `now` returns the same answer. Callers driving a stall loop call
+// waitDuration to compute a sleep target, sleep, then call allow() to
+// actually claim the token.
+//
+// Backwards or zero elapsed time is treated as zero elapsed, mirroring
+// allow(): the bucket never credits clock skew, so the reported wait is
+// always the conservative "full refill from current state" duration.
+func (tb *tokenBucket) waitDuration(now time.Time) time.Duration {
+	elapsed := now.Sub(tb.lastUpdate).Seconds()
+	tokens := tb.tokens
+	if elapsed > 0 {
+		tokens = math.Min(tb.burst, tokens+elapsed*tb.rate)
+	}
+	if tokens >= 1 {
+		return 0
+	}
+	needed := 1 - tokens
+	return time.Duration(needed / tb.rate * float64(time.Second))
 }

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -234,6 +234,33 @@ func TestReadStall_FastPathDoesNotCallOnStall(t *testing.T) {
 	}
 }
 
+func TestReadStall_PreCanceledCtxRejectsBeforeAllow(t *testing.T) {
+	// If ctx is already canceled at entry, readStall must return ctx.Err()
+	// without consuming a token from the bucket -- even when the bucket has
+	// tokens available. This keeps the readLoop's ctx semantics consistent
+	// across both layers (the subsequent conn.Read(ctx) would also fail
+	// immediately) and avoids burning bucket capacity on a connection that
+	// is already going away.
+	bucket := newTokenBucket(1, 5, time.Now())
+	beforeTokens := bucket.tokens
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := 0
+	err := readStall(ctx, bucket, func() { called++ })
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("onStall must not fire on pre-canceled ctx, got %d calls", called)
+	}
+	if bucket.tokens != beforeTokens {
+		t.Fatalf("bucket must not be debited on pre-canceled ctx: before=%v after=%v",
+			beforeTokens, bucket.tokens)
+	}
+}
+
 func TestReadStall_StallsUntilTokenAvailable(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		bucket := newTokenBucket(1, 1, time.Now())

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -112,3 +112,98 @@ func TestTokenBucket_BackwardsClockIgnored(t *testing.T) {
 		t.Fatal("expected reject when clock moves backwards")
 	}
 }
+
+func TestTokenBucket_WaitDurationZeroWhenAvailable(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 3, now)
+
+	// Initially full, waitDuration must be 0.
+	if d := tb.waitDuration(now); d != 0 {
+		t.Fatalf("expected 0 at full bucket, got %v", d)
+	}
+
+	// After consuming 1 of 3, still 2 left -> waitDuration still 0.
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+	if d := tb.waitDuration(now); d != 0 {
+		t.Fatalf("expected 0 with tokens remaining, got %v", d)
+	}
+}
+
+func TestTokenBucket_WaitDurationAfterExhaustion(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(2, 1, now) // 2 tokens/sec, burst 1
+
+	// Exhaust the burst.
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+
+	// At rate=2, one token refills in 0.5s exactly.
+	if d := tb.waitDuration(now); d != 500*time.Millisecond {
+		t.Fatalf("expected 500ms after exhaustion, got %v", d)
+	}
+}
+
+func TestTokenBucket_WaitDurationAccountsForElapsed(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 1, now) // 1 token/sec, burst 1
+
+	// Exhaust the burst.
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+
+	// After 0.3s elapsed, 0.3 token has accumulated lazily; we still need
+	// 0.7 more, which at rate=1 means 0.7s of additional wait.
+	now = now.Add(300 * time.Millisecond)
+	if d := tb.waitDuration(now); d != 700*time.Millisecond {
+		t.Fatalf("expected 700ms with 0.3s elapsed, got %v", d)
+	}
+}
+
+func TestTokenBucket_WaitDurationDoesNotMutateState(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 1, now) // 1 token/sec, burst 1
+
+	// Exhaust the burst.
+	if !tb.allow(now) {
+		t.Fatal("expected initial allow")
+	}
+
+	// Calling waitDuration repeatedly with the same `now` must return the
+	// same answer -- it must not credit elapsed time on its own.
+	later := now.Add(400 * time.Millisecond)
+	d1 := tb.waitDuration(later)
+	d2 := tb.waitDuration(later)
+	if d1 != d2 {
+		t.Fatalf("waitDuration not idempotent: %v vs %v", d1, d2)
+	}
+
+	// And after we wait the reported duration, allow at that exact instant
+	// must succeed -- proving waitDuration isn't lying about when refill
+	// completes (and hasn't silently consumed a token already).
+	target := later.Add(d1)
+	if !tb.allow(target) {
+		t.Fatalf("expected allow at later+waitDuration (=%v), got reject", target)
+	}
+}
+
+func TestTokenBucket_WaitDurationBackwardsClockIgnored(t *testing.T) {
+	// Mirroring TestTokenBucket_BackwardsClockIgnored: a backwards clock
+	// must not credit negative elapsed time. waitDuration with `earlier`
+	// should report the full refill window (1s at rate=1), same as if no
+	// time had passed at all -- never a negative or wrapped duration.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(1, 1, start)
+
+	if !tb.allow(start) {
+		t.Fatal("expected initial allow")
+	}
+
+	earlier := start.Add(-10 * time.Second)
+	if d := tb.waitDuration(earlier); d != time.Second {
+		t.Fatalf("expected 1s with backwards clock, got %v", d)
+	}
+}

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,7 +1,9 @@
 package mocrelay
 
 import (
+	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -206,4 +208,74 @@ func TestTokenBucket_WaitDurationBackwardsClockIgnored(t *testing.T) {
 	if d := tb.waitDuration(earlier); d != time.Second {
 		t.Fatalf("expected 1s with backwards clock, got %v", d)
 	}
+}
+
+func TestReadStall_NilBucket(t *testing.T) {
+	// A nil bucket means rate limiting is disabled. readStall must return
+	// immediately without ever consulting ctx.
+	if err := readStall(context.Background(), nil, nil); err != nil {
+		t.Fatalf("expected nil error with nil bucket, got %v", err)
+	}
+}
+
+func TestReadStall_FastPathDoesNotCallOnStall(t *testing.T) {
+	// When the bucket has tokens available, readStall returns immediately
+	// and onStall must NOT fire -- the callback exists to count actual
+	// stalls, not every successful read.
+	now := time.Now()
+	bucket := newTokenBucket(1, 3, now)
+
+	called := 0
+	if err := readStall(context.Background(), bucket, func() { called++ }); err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("onStall called %d times on fast path; expected 0", called)
+	}
+}
+
+func TestReadStall_StallsUntilTokenAvailable(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		bucket := newTokenBucket(1, 1, time.Now())
+		// Consume the burst -- next allow needs ~1s of refill.
+		if !bucket.allow(time.Now()) {
+			t.Fatal("expected initial allow")
+		}
+
+		called := 0
+		start := time.Now()
+		err := readStall(context.Background(), bucket, func() { called++ })
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("expected nil err, got %v", err)
+		}
+		// At rate=1, full refill takes ~1s. synctest fake clock should
+		// advance time deterministically to that moment.
+		if elapsed < time.Second {
+			t.Fatalf("expected >=1s stall, got %v", elapsed)
+		}
+		// onStall fires exactly once per stall window: when the slow path
+		// kicks in. Subsequent re-checks inside the loop must not double-count.
+		if called != 1 {
+			t.Fatalf("expected onStall called once, got %d", called)
+		}
+	})
+}
+
+func TestReadStall_CtxCancelExits(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		bucket := newTokenBucket(1, 1, time.Now())
+		if !bucket.allow(time.Now()) {
+			t.Fatal("expected initial allow")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel partway through the stall -- well before the 1s refill.
+		time.AfterFunc(100*time.Millisecond, cancel)
+
+		err := readStall(ctx, bucket, nil)
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
 }

--- a/relay.go
+++ b/relay.go
@@ -25,6 +25,8 @@ type Relay struct {
 	maxMessageLength int64
 	pingInterval     time.Duration
 	pingTimeout      time.Duration
+	readRate         float64
+	readBurst        int
 	info             *RelayInfo
 	metrics          *relayMetrics
 	rejectionMetrics *rejectionMetrics
@@ -59,6 +61,31 @@ type RelayOptions struct {
 	// If a pong or write does not complete within this duration, the connection is closed.
 	// Default: 10 seconds
 	PingTimeout time.Duration
+
+	// ReadRate is the maximum messages-per-second the readLoop will pull
+	// off the WebSocket on a single connection. When the per-connection
+	// budget is exhausted the readLoop STALLS -- conn.Read is simply not
+	// invoked until a token refills -- so back-pressure propagates to the
+	// client through the TCP receive window. The relay never spends parse
+	// or signature-verification CPU on throttled traffic.
+	//
+	// This is the readLoop-level total cap and is independent of the
+	// per-message-type rate limit middlewares (Event/Req/Count/Auth),
+	// which run after parse and let operators tune category-specific
+	// budgets. Both layers compose: readLoop acts first as a coarse
+	// floodgate, middlewares then refine.
+	//
+	// Zero or negative disables the limit (default).
+	ReadRate float64
+
+	// ReadBurst is the bucket capacity for the readLoop rate limit. Must
+	// be >= 1 if ReadRate > 0; the constructor panics on misconfiguration
+	// rather than silently degrading. The bucket starts full at OnStart
+	// so a freshly-connected client can burst up to ReadBurst messages
+	// immediately, then is throttled to ReadRate long-term.
+	//
+	// Ignored when ReadRate <= 0.
+	ReadBurst int
 
 	// Info is the NIP-11 Relay Information Document.
 	// If set, the relay will respond to HTTP requests with
@@ -123,12 +150,18 @@ func NewRelay(handler Handler, opts *RelayOptions) *Relay {
 		pingTimeout = 10 * time.Second
 	}
 
+	if opts.ReadRate > 0 && opts.ReadBurst < 1 {
+		panic("mocrelay: RelayOptions.ReadBurst must be >= 1 when ReadRate > 0")
+	}
+
 	return &Relay{
 		handler:          handler,
 		logger:           logger,
 		maxMessageLength: maxMessageLength,
 		pingInterval:     pingInterval,
 		pingTimeout:      pingTimeout,
+		readRate:         opts.ReadRate,
+		readBurst:        opts.ReadBurst,
 		info:             opts.Info,
 		metrics:          newRelayMetrics(opts.Registerer),
 		rejectionMetrics: newRejectionMetrics(opts.Registerer),
@@ -330,7 +363,26 @@ func (r *Relay) readLoop(
 	recv chan<- *ClientMsg,
 	send chan<- *ServerMsg,
 ) error {
+	// Per-connection token bucket for the readLoop-level rate limit.
+	// Disabled when ReadRate <= 0; readStall short-circuits on nil bucket.
+	var bucket *tokenBucket
+	if r.readRate > 0 {
+		bucket = newTokenBucket(r.readRate, r.readBurst, time.Now())
+	}
+
+	var onStall func()
+	if r.metrics != nil {
+		onStall = r.metrics.ReadStallsTotal.Inc
+	}
+
 	for {
+		// Stall before conn.Read so a throttled client never costs us a
+		// frame read, parse, or signature verify. Back-pressure rides on
+		// the TCP receive window once the OS-level WebSocket buffer fills.
+		if err := readStall(ctx, bucket, onStall); err != nil {
+			return err
+		}
+
 		typ, payload, err := conn.Read(ctx)
 		if err != nil {
 			return err

--- a/relay_test.go
+++ b/relay_test.go
@@ -136,3 +136,38 @@ func TestRelay_Shutdown(t *testing.T) {
 		}
 	})
 }
+
+func TestNewRelay_ReadRateLimitValidation(t *testing.T) {
+	t.Run("disabled accepts any ReadBurst", func(t *testing.T) {
+		// ReadRate <= 0 disables the limit and ReadBurst is ignored entirely,
+		// so even ReadBurst=0 (the zero value) must not panic.
+		_ = NewRelay(NewNopHandler(), &RelayOptions{ReadRate: 0, ReadBurst: 0})
+		_ = NewRelay(NewNopHandler(), &RelayOptions{ReadRate: -1, ReadBurst: -5})
+	})
+
+	t.Run("enabled with valid burst", func(t *testing.T) {
+		_ = NewRelay(NewNopHandler(), &RelayOptions{ReadRate: 10, ReadBurst: 1})
+		_ = NewRelay(NewNopHandler(), &RelayOptions{ReadRate: 10, ReadBurst: 100})
+	})
+
+	t.Run("enabled with invalid burst panics", func(t *testing.T) {
+		// Burst < 1 with rate > 0 means a freshly-connected client would
+		// stall on its very first read for 1/rate seconds -- almost
+		// certainly a misconfiguration. Fail loudly at construction time
+		// rather than silently degrading. Mirrors the per-message-type
+		// rate limit middlewares.
+		for _, burst := range []int{0, -1, -100} {
+			func() {
+				defer func() {
+					if recover() == nil {
+						t.Errorf("expected panic for ReadBurst=%d, got none", burst)
+					}
+				}()
+				_ = NewRelay(NewNopHandler(), &RelayOptions{
+					ReadRate:  10,
+					ReadBurst: burst,
+				})
+			}()
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the **readLoop-layer counterpart** to the per-message-type rate
limit middlewares shipped in #80. Where those middlewares reject
*after* parse, this one stalls the readLoop *before* `conn.Read`, so
a throttled client never costs the relay parse or signature-verify
CPU. Back-pressure rides on the TCP receive window.

The two layers compose as defense in depth: readLoop = coarse
floodgate, middlewares = category refinement.

## Public API

```go
type RelayOptions struct {
    // ... existing ...
    ReadRate  float64 // messages/sec; <=0 disables (default)
    ReadBurst int     // bucket capacity; must be >=1 if ReadRate > 0
}
```

`ReadRate > 0 && ReadBurst < 1` panics in `NewRelay`, mirroring the
strictness of the per-message-type middleware constructors.

## Commits

1. **refactor**: add `tokenBucket.waitDuration(now)` -- pure read of
   the bucket state that returns when the next token will refill.
   Existing `allow()` is enough for middlewares (reject-on-empty); the
   stall path needs to know how long to sleep.
2. **feat**: readLoop integration. New `readStall` helper drives the
   wait loop with `onStall` callback (one increment per stall window,
   not per inner-loop retry). New `mocrelay_read_stalls_total` Counter.
3. **docs**: CLAUDE.md "Operational Hardening" split into
   Application-layer / readLoop-layer / Layer composition subsections.
   The old "Out of scope" paragraph that *promised* a future readLoop
   layer is now structurally out of date and is rewritten.

## Test plan

- [x] `go test ./...` -- all PASS
- [x] `go vet ./...` -- clean
- [x] `lefthook` pre-commit -- PASS on each commit
- [x] `tokenBucket.waitDuration`: 5 unit tests (zero-when-available,
      exact-after-exhaustion, elapsed-time-accounting, idempotence
      via `waitDuration -> Add -> allow` end-to-end, backwards-clock
      safety)
- [x] `readStall`: 4 unit tests (nil bucket no-op, fast-path skips
      onStall, slow path under `synctest` fake clock, ctx cancel
      mid-stall returns `context.Canceled`)
- [x] `NewRelay` validation: 3 subtests covering disabled (any
      `ReadBurst` OK), enabled with valid burst, enabled with invalid
      burst panics across `{0, -1, -100}`

## Notes for review

The slow-path tests use `testing/synctest` bubbles for deterministic
fake-clock advancement (no real wall time). The fast-path / nil-bucket
tests don't need the bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)