### PR TITLE
ci: Add dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,13 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    reviewers:
+      - high-moctane
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `github-actions` package ecosystem to dependabot config for automated Actions version updates

## Test plan
- [ ] Verify dependabot creates PRs for outdated actions (checkout, setup-go, fetch-metadata)

🔧 Generated with [Claude Code](https://claude.com/claude-code)