### PR TITLE
ci: Migrate dependabot review requests to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @high-moctane

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       timezone: Asia/Tokyo
     commit-message:
       prefix: "deps"
-    reviewers:
-      - high-moctane
     ignore:
       - dependency-name: "go"
       - dependency-name: "toolchain"


### PR DESCRIPTION
## Summary
- GitHub retired the `dependabot.yml` `reviewers:` option on 2025-05-20 in favor of CODEOWNERS
- Add `.github/CODEOWNERS` (`* @high-moctane`) to restore review requests on dependabot PRs
- Remove the now-inert `reviewers:` field from `.github/dependabot.yml`

🌸 Generated with [Claude Code](https://claude.com/claude-code)